### PR TITLE
Drop page_num once CMR-Search-After is in use

### DIFF
--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -281,7 +281,10 @@ function cmr_headers(search_after=nothing)
 end
 
 function cmr_query(query::Dict; page_num, page_size)
-    q = Dict{String,Any}("page_num" => page_num, "page_size" => page_size)
+    q = Dict{String,Any}("page_size" => page_size)
+    # CMR rejects `page_num` once a `CMR-Search-After` header is in play, so the caller
+    # passes `page_num=nothing` for every page after the first.
+    isnothing(page_num) || (q["page_num"] = page_num)
     for (k, v) in query
         isnothing(v) || (q[string(k)] = v)
     end
@@ -345,6 +348,10 @@ function request(
         next_search_after in seen_search_after && break
         push!(seen_search_after, next_search_after)
         search_after = next_search_after
+        # `page_num` and `CMR-Search-After` are mutually exclusive: sending both makes CMR
+        # answer HTTP 400 "page_num is not allowed with search-after", so the first page's
+        # `page_num` must be dropped before the second request goes out.
+        q = cmr_query(query; page_num=nothing, page_size)
     end
     vv
 end

--- a/test/search.jl
+++ b/test/search.jl
@@ -115,8 +115,40 @@ end
     @test requests[1].query === nothing
     @test occursin("short_name=TEST", requests[1].body)
     @test occursin("page_size=2", requests[1].body)
+    @test occursin("page_num=1", requests[1].body)
     @test requests[2].headers["CMR-Search-After"] == "next-page"
+    # CMR answers HTTP 400 "page_num is not allowed with search-after" if both are sent, so
+    # the second page must carry the header and *not* `page_num`.
+    @test !occursin("page_num", requests[2].body)
+    @test occursin("page_size=2", requests[2].body)
+    @test occursin("short_name=TEST", requests[2].body)
     @test isempty(responses)
+end
+
+@testset "CMR GET pagination drops page_num too" begin
+    requests = []
+    responses = [
+        HTTP.Response(
+            200,
+            ["CMR-Search-After" => "next-page"],
+            cmr_response(["G1"], "granule"; hits=2),
+        ),
+        HTTP.Response(200, [], cmr_response(["G2"], "granule"; hits=2)),
+    ]
+
+    EarthData.request(
+        "https://example.test/granules",
+        Dict("short_name" => "TEST"),
+        EarthData.Granules.UMM_G;
+        page_size=1,
+        all=true,
+        method=:GET,
+        requester=recording_requester(responses, requests),
+    )
+
+    @test requests[1].query["page_num"] == 1
+    @test !haskey(requests[2].query, "page_num")
+    @test requests[2].query["page_size"] == 1
 end
 
 @testset "CMR GET compatibility" begin


### PR DESCRIPTION
`request(...; all=true)` fails on the second page: CMR rejects `page_num` and `CMR-Search-After` together with

```
HTTP 400  page_num is not allowed with search-after
```

The query dict is built once and reused across the pagination loop, so page 1 succeeds and page 2 always 400s. Any `all=true` search exceeding one page is unusable.

Fix: `cmr_query` accepts `page_num=nothing` and omits the key; the loop rebuilds the query without it after the first response.

Verified live — 4747 granules over 475 pages, where `main` errors on page 2. Tests assert the param is present on request 1 and absent on request 2, for both POST and GET.