### PR TITLE
Add Type-based URL selection and a unit-aware granule_size

### DIFF
--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -43,6 +43,36 @@ https_urls(gg)
 s3_urls(gg)
 ```
 
+### Selecting the data file
+
+A record's related URLs are not all data. A single MCD43A3 granule, for example, carries
+eight: the HTTPS file, its S3 copy, a DOI landing page, a metadata sidecar, browse imagery
+and a cloud-credentials endpoint. `https_urls` returns most of those, so filter on
+`RelatedUrls[].Type` instead — `data_urls` does exactly that, keeping only `"GET DATA"`:
+
+```julia
+data_urls(first(gg))          # the file
+download(gg, "data"; type="GET DATA")
+```
+
+The S3 copy of the same file is typed `"GET DATA VIA DIRECT ACCESS"`:
+
+```julia
+urls(first(gg); scheme=:s3, type="GET DATA VIA DIRECT ACCESS")
+```
+
+### Granule sizes
+
+`granule_size` reports a granule's size in bytes:
+
+```julia
+granule_size(first(gg))
+```
+
+It prefers `SizeInBytes`, and otherwise converts `Size` using the record's `SizeUnit`.
+`Size` alone is unit-less — providers commonly report megabytes — so reading it without
+the unit understates the size by a factor of about a million.
+
 ## Earthdata credentials
 
 NASA Earthdata downloads require credentials. Store them in your `.netrc` file

--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -354,18 +354,29 @@ function scheme_prefix(scheme)
     endswith(s, ":") ? s : s * ":"
 end
 
-function urls(item::AbstractJSON; scheme=nothing)
+url_type(u) = hasproperty(u, :Type) ? getproperty(u, :Type) : nothing
+
+"""
+    urls(item; scheme=nothing, type=nothing) -> Vector{String}
+
+Related URLs of a UMM record, optionally filtered by URL `scheme` (`:https`, `:s3`) and by
+`RelatedUrls[].Type` (`"GET DATA"`, `"GET DATA VIA DIRECT ACCESS"`,
+`"VIEW RELATED INFORMATION"`, ...).
+"""
+function urls(item::AbstractJSON; scheme=nothing, type=nothing)
     related_urls = getproperty(item, :RelatedUrls)
     isnothing(related_urls) && return String[]
-    result = [u.URL for u in related_urls]
+    selected = related_urls
+    isnothing(type) || (selected = filter(u -> url_type(u) == type, selected))
+    result = [u.URL for u in selected]
     isnothing(scheme) && return result
     filter(startswith(scheme_prefix(scheme)), result)
 end
 
-function urls(items::AbstractVector{<:AbstractJSON}; scheme=nothing)
+function urls(items::AbstractVector{<:AbstractJSON}; scheme=nothing, type=nothing)
     result = String[]
     for item in items
-        append!(result, urls(item; scheme))
+        append!(result, urls(item; scheme, type))
     end
     return result
 end
@@ -373,35 +384,122 @@ end
 https_urls(item) = urls(item; scheme=:https)
 s3_urls(item) = urls(item; scheme=:s3)
 
-function download_url(item; scheme=:https)
-    candidates = urls(item; scheme)
+"""
+    data_urls(item; scheme=:https) -> Vector{String}
+
+URLs of the granule's data file(s), i.e. the related URLs typed `"GET DATA"`.
+
+Records commonly carry several related URLs that are not the data: a DOI landing page, a
+metadata sidecar, browse imagery, a cloud-credentials endpoint. Filtering on the scheme
+alone does not separate those from the file, so prefer this over [`https_urls`](@ref) when
+what you want is something to download. Note the S3 copy of the same file is typed
+`"GET DATA VIA DIRECT ACCESS"` and so is *not* returned; use
+`urls(item; scheme=:s3, type="GET DATA VIA DIRECT ACCESS")` for that.
+"""
+data_urls(item; scheme=:https) = urls(item; scheme, type="GET DATA")
+
+function download_url(item; scheme=:https, type=nothing)
+    candidates = urls(item; scheme, type)
     isempty(candidates) ? nothing : first(candidates)
 end
 
-function write_urls(io::IO, items::AbstractVector{<:AbstractJSON}; scheme=:https)
-    write_urls(io, urls(items; scheme))
+const size_unit_factors = Dict(
+    "BYTES" => 1,
+    "B" => 1,
+    "KB" => 1024,
+    "MB" => 1024^2,
+    "GB" => 1024^3,
+    "TB" => 1024^4,
+)
+
+"""
+    size_unit_factor(unit) -> Int
+
+Bytes per `unit`, for the `SizeUnit` values UMM allows (`"Bytes"`, `"KB"`, `"MB"`, `"GB"`,
+`"TB"`; binary multiples). Throws for an unrecognised unit rather than guessing, since a
+wrong factor silently misreports a size by three orders of magnitude.
+"""
+function size_unit_factor(unit::AbstractString)
+    key = uppercase(strip(unit))
+    haskey(size_unit_factors, key) ||
+        throw(ArgumentError("Unrecognised UMM SizeUnit: $(repr(unit))"))
+    return size_unit_factors[key]
+end
+
+"""
+    granule_size(granule; default_unit="MB") -> Union{Int,Nothing}
+
+Size of a granule in bytes, from `DataGranule.ArchiveAndDistributionInformation`, or
+`nothing` when the record does not report one.
+
+`SizeInBytes` is used when present. Otherwise `Size` is converted using its `SizeUnit` —
+`Size` is unit-less on its own, and providers do report units other than bytes, so reading
+the number without the unit is how a megabyte figure gets mistaken for a byte count. A
+record that gives `Size` with no `SizeUnit` is read as `default_unit`, which is what the
+DAACs mean in practice; pass `default_unit` explicitly if a provider differs.
+
+Sizes of multiple files are summed, since together they are the granule.
+"""
+function granule_size(granule::AbstractJSON; default_unit::AbstractString="MB")
+    data_granule = getproperty(granule, :DataGranule)
+    isnothing(data_granule) && return nothing
+    entries = getproperty(data_granule, :ArchiveAndDistributionInformation)
+    isnothing(entries) && return nothing
+    total = 0
+    found = false
+    for entry in entries
+        bytes = entry.SizeInBytes
+        if isnothing(bytes)
+            isnothing(entry.Size) && continue
+            unit = something(entry.SizeUnit, default_unit)
+            bytes = round(Int, entry.Size * size_unit_factor(unit))
+        end
+        total += bytes
+        found = true
+    end
+    return found ? total : nothing
+end
+
+function write_urls(
+    io::IO,
+    items::AbstractVector{<:AbstractJSON};
+    scheme=:https,
+    type=nothing,
+)
+    write_urls(io, urls(items; scheme, type))
 end
 
 function write_urls(
     fn::AbstractString,
     items::AbstractVector{<:AbstractJSON};
     scheme=:https,
+    type=nothing,
 )
-    write_urls(fn, urls(items; scheme))
+    write_urls(fn, urls(items; scheme, type))
 end
 
-function write_urls(items::AbstractVector{<:AbstractJSON}; scheme=:https)
-    write_urls(urls(items; scheme))
+function write_urls(items::AbstractVector{<:AbstractJSON}; scheme=:https, type=nothing)
+    write_urls(urls(items; scheme, type))
 end
 
 function download(
     items::AbstractVector{<:AbstractJSON},
     folder::AbstractString=".";
     scheme=:https,
+    type=nothing,
     kwargs...,
 )
-    download(urls(items; scheme), folder; kwargs...)
+    download(urls(items; scheme, type), folder; kwargs...)
 end
 
-export granules, collections, urls, https_urls, s3_urls, download_url, write_urls, download
+export granules,
+    collections,
+    urls,
+    https_urls,
+    s3_urls,
+    data_urls,
+    download_url,
+    granule_size,
+    write_urls,
+    download
 end

--- a/test/search.jl
+++ b/test/search.jl
@@ -19,8 +19,23 @@ function granule_umm(id)
         "GranuleUR" => id,
         "RelatedUrls" => [
             Dict("URL" => "https://example.test/$id.h5", "Type" => "GET DATA"),
-            Dict("URL" => "s3://example-bucket/$id.h5", "Type" => "GET DATA"),
+            # A real record types the S3 copy of the same file separately, and carries
+            # several URLs that are not the data at all.
+            Dict(
+                "URL" => "s3://example-bucket/$id.h5",
+                "Type" => "GET DATA VIA DIRECT ACCESS",
+            ),
+            Dict(
+                "URL" => "https://example.test/s3credentials",
+                "Type" => "VIEW RELATED INFORMATION",
+            ),
         ],
+        "DataGranule" => Dict(
+            "DayNightFlag" => "DAY",
+            "ProductionDateTime" => "2020-01-01T00:00:00Z",
+            "ArchiveAndDistributionInformation" =>
+                [Dict("Name" => "$id.h5", "Size" => 1.5, "SizeUnit" => "MB")],
+        ),
         "MetadataSpecification" =>
             Dict("URL" => "https://example.test", "Version" => "1.6.6", "Name" => "UMM-G"),
         "ProviderDates" => [Dict("Type" => "Insert", "Date" => "2020-01-01T00:00:00Z")],
@@ -46,6 +61,10 @@ function collection_umm(id)
         "Abstract" => "Test collection",
         "DOI" => Dict(),
     )
+end
+
+struct SizelessItem <: EarthData.AbstractJSON
+    DataGranule::Nothing
 end
 
 function cmr_response(ids, concept_type; hits=length(ids))
@@ -167,15 +186,60 @@ end
         ),
     )
 
-    @test EarthData.urls(granule) ==
-          ["https://example.test/G1.h5", "s3://example-bucket/G1.h5"]
-    @test EarthData.urls(granule; scheme=:https) == ["https://example.test/G1.h5"]
-    @test EarthData.https_urls(granule) == ["https://example.test/G1.h5"]
+    @test EarthData.urls(granule) == [
+        "https://example.test/G1.h5",
+        "s3://example-bucket/G1.h5",
+        "https://example.test/s3credentials",
+    ]
+    @test EarthData.urls(granule; scheme=:https) ==
+          ["https://example.test/G1.h5", "https://example.test/s3credentials"]
+    @test EarthData.https_urls(granule) ==
+          ["https://example.test/G1.h5", "https://example.test/s3credentials"]
     @test EarthData.s3_urls(granule) == ["s3://example-bucket/G1.h5"]
     @test EarthData.download_url(granule; scheme=:https) == "https://example.test/G1.h5"
     @test EarthData.download_url(granule; scheme=:ftp) === nothing
     @test EarthData.urls([granule, granule]; scheme=:s3) ==
           ["s3://example-bucket/G1.h5", "s3://example-bucket/G1.h5"]
+
+    # Filtering on the scheme alone keeps the credentials endpoint; filtering on the type
+    # is what isolates the file.
+    @test EarthData.data_urls(granule) == ["https://example.test/G1.h5"]
+    @test EarthData.urls(granule; type="GET DATA VIA DIRECT ACCESS") ==
+          ["s3://example-bucket/G1.h5"]
+    @test EarthData.urls(granule; scheme=:https, type="GET DATA VIA DIRECT ACCESS") == []
+    @test EarthData.urls(granule; type="NOT A TYPE") == []
+    @test EarthData.download_url(granule; type="GET DATA") == "https://example.test/G1.h5"
+    @test EarthData.data_urls([granule, granule]) ==
+          ["https://example.test/G1.h5", "https://example.test/G1.h5"]
+end
+
+@testset "Granule sizes" begin
+    requests = []
+    responses = [HTTP.Response(200, [], cmr_response(["G1"], "granule"))]
+    granule = only(
+        EarthData.request(
+            "https://example.test/granules",
+            Dict("short_name" => "TEST"),
+            EarthData.Granules.UMM_G;
+            requester=recording_requester(responses, requests),
+        ),
+    )
+
+    # `Size` is 1.5 with `SizeUnit` "MB", so the unit has to be read: taking the number
+    # alone would report 1 byte where the file is 1.5 MiB.
+    @test EarthData.granule_size(granule) == round(Int, 1.5 * 1024^2)
+
+    @test EarthData.size_unit_factor("Bytes") == 1
+    @test EarthData.size_unit_factor("b") == 1
+    @test EarthData.size_unit_factor("KB") == 1024
+    @test EarthData.size_unit_factor(" mb ") == 1024^2
+    @test EarthData.size_unit_factor("GB") == 1024^3
+    @test EarthData.size_unit_factor("TB") == 1024^4
+    @test_throws ArgumentError EarthData.size_unit_factor("furlongs")
+
+    # A record with no size information reports nothing rather than zero, so a caller can
+    # tell "not stated" from "empty".
+    @test EarthData.granule_size(SizelessItem(nothing)) === nothing
 end
 
 @testset "Batch downloads" begin
@@ -201,10 +265,20 @@ end
 
     commands = Cmd[]
     folder = mktempdir()
-    paths = EarthData.download(granules, folder; runner=cmd -> push!(commands, cmd))
+    paths = EarthData.download(
+        granules,
+        folder;
+        type="GET DATA",
+        runner=cmd -> push!(commands, cmd),
+    )
 
     @test paths == [joinpath(folder, "G1.h5"), joinpath(folder, "G2.h5")]
     @test length(commands) == 1
+
+    # Without the type filter every HTTPS related URL is fetched, including the cloud
+    # credentials endpoint — which is why `type` exists.
+    unfiltered = EarthData.download(granules, folder; runner=Returns(nothing))
+    @test joinpath(folder, "s3credentials") in unfiltered
     command_string = string(only(commands))
     @test occursin("-i", command_string)
     @test occursin("-c", command_string)


### PR DESCRIPTION
Two things a caller needs before downloading, neither currently available.

**1. Which related URL is the data?** An MCD43A3 granule carries **eight**. `https_urls` returns most of them — the DOI landing page, the `.cmr.xml` sidecar, browse imagery and an `s3credentials` endpoint are all HTTPS too, so filtering on scheme cannot pick out the file. `urls` gains a `type` filter and `data_urls` keeps only `"GET DATA"`. (The S3 copy is typed `"GET DATA VIA DIRECT ACCESS"`.)

This also fixes an unreported bug: `download(granules, folder)` currently fetches every HTTPS related URL, `s3credentials` included.

**2. How big is it?** `granule_size` reads `DataGranule.ArchiveAndDistributionInformation`, preferring `SizeInBytes` and otherwise converting `Size` by its `SizeUnit`. `Size` alone is unit-less and providers do report MB, so reading the number without the unit understates the size by about a million. An unrecognised unit throws rather than guessing.

Defaults are unchanged. Verified live on MCD43A3: 8 URLs per granule, `data_urls` returns the one `.hdf`, sizes come back in bytes.