### PR TITLE
Add Earthdata Login bearer-token support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.0"
 
 [deps]
 Aria2_jll = "9ab3bdc3-1250-5043-8fac-ac7e82d2cbc9"
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"

--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -55,6 +55,31 @@ EarthData.netrc!("earthdata_username", "earthdata_password")
 The file is plaintext, so use the same care you would use for any credential
 file.
 
+### Bearer tokens
+
+Earthdata Login also issues bearer tokens, which is the credential an HTTP client
+needs when it sets its own headers rather than delegating to curl's `.netrc`
+support. `EarthData.token()` resolves one from `ENV["EARTHDATA_TOKEN"]`, else the
+first non-comment line of `~/.edl_token`, and `auth_headers` builds the header:
+
+```julia
+headers = EarthData.auth_headers()          # Authorization: Bearer <token>
+Downloads.download(data_urls(first(gg))[1], "granule.h5"; headers)
+```
+
+Resolution never touches the network. To obtain a token from your `.netrc`
+credentials instead, call `EarthData.token_from_netrc()` explicitly:
+
+```julia
+ENV["EARTHDATA_TOKEN"] = EarthData.token_from_netrc()
+```
+
+!!! warning "Two concurrent tokens, maximum"
+    An account may hold two live tokens; requesting a third returns HTTP 403.
+    `token_from_netrc()` lists existing tokens and returns the first, so it cannot
+    exhaust the quota; `token_from_netrc(create=true)` will consume a slot when the
+    account has none. Never call either from a retry loop. Tokens last 60 days.
+
 ## Downloading files
 
 Download one URL to a path:

--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -7,8 +7,10 @@ using JSON3
 using Extents
 using StructTypes
 import Downloads
+import Base64
 
 include("utils.jl")
+include("auth.jl")
 abstract type AbstractJSON end
 include("umm/granules.jl")
 include("umm/collections.jl")

--- a/src/auth.jl
+++ b/src/auth.jl
@@ -1,0 +1,175 @@
+"""
+Earthdata Login (EDL) bearer tokens.
+
+`netrc!` writes a username and password for tools that speak `.netrc`. A bearer token is
+the other credential EDL issues, and it is what an HTTP client needs when it sets its own
+headers — `Authorization: Bearer <token>` — rather than delegating to curl's netrc support.
+
+Resolution ([`token`](@ref)) is deliberately offline. Obtaining a token
+([`token_from_netrc`](@ref)) is a separate, explicit call, because an account may hold only
+**two** live tokens and creation must never be reachable from a retry loop.
+"""
+
+const token_page = "https://urs.earthdata.nasa.gov/users/tokens"
+const token_api = "https://urs.earthdata.nasa.gov/api/users"
+
+"""
+    token() -> String
+
+The Earthdata Login bearer token, from the environment or a token file.
+
+Searches, in order:
+
+1. `ENV["EARTHDATA_TOKEN"]`
+2. `~/.edl_token` (first non-empty, non-comment line)
+
+Throws an `ErrorException` with setup instructions when neither is present.
+
+This never contacts the network. To obtain a token from `.netrc` credentials instead, call
+[`token_from_netrc`](@ref) explicitly.
+
+`EARTHDATA_TOKEN` is a community convention rather than a NASA-defined variable; no NASA
+tooling reads it for you.
+
+Treat the returned string as a secret: it authenticates as the account for 60 days.
+"""
+function token()
+    tok = get(ENV, "EARTHDATA_TOKEN", "")
+    isempty(strip(tok)) || return String(strip(tok))
+
+    path = joinpath(homedir(), ".edl_token")
+    if isfile(path)
+        for line in readlines(path)
+            s = strip(line)
+            (isempty(s) || startswith(s, "#")) && continue
+            return String(s)
+        end
+    end
+
+    error("""
+    No NASA Earthdata Login token found. Create one at
+        $(token_page)
+    and either
+
+        export EARTHDATA_TOKEN="your-token-here"
+
+    or write it to ~/.edl_token. A token lasts 60 days, and an account may hold at most
+    two at a time — reuse an existing one rather than requesting a third, which fails.
+
+    Alternatively, with ~/.netrc credentials for urs.earthdata.nasa.gov in place:
+        EarthData.token_from_netrc()
+    """)
+end
+
+"""
+    token_from_netrc(; create=false, machine="urs.earthdata.nasa.gov") -> String
+
+Fetch an Earthdata Login bearer token using the username and password stored in `.netrc`.
+
+This is a network call, kept out of [`token`](@ref) on purpose: a credential lookup that
+can hit the network is a lookup that can hang or rate-limit inside a retry loop.
+
+!!! warning "Two concurrent tokens, maximum"
+    EDL allows an account two live tokens; requesting a third returns HTTP 403. With
+    `create=false` (the default) this only *lists* tokens and returns the first, so it
+    cannot exhaust the quota. `create=true` will consume the second slot when none exists.
+    Do not call this from a retry loop.
+"""
+function token_from_netrc(;
+    create::Bool=false,
+    machine::AbstractString="urs.earthdata.nasa.gov",
+    requester=HTTP.request,
+)
+    user, pass = netrc_credentials(machine)
+    auth = "Basic " * Base64.base64encode(string(user, ":", pass))
+    headers = ["Authorization" => auth, "Accept" => "application/json"]
+
+    endpoint = create ? "$(token_api)/token" : "$(token_api)/tokens"
+    method = create ? "POST" : "GET"
+    r = requester(method, endpoint, headers; status_exception=false)
+    if r.status >= 400
+        error("""
+        Earthdata Login rejected the token request ($(method) $(endpoint), HTTP $(r.status)):
+
+        $(String(r.body))
+
+        HTTP 401 means the .netrc credentials for "$(machine)" are wrong. HTTP 403 on a
+        creation request usually means the two-token limit is already reached — list them
+        at $(token_page) and reuse one.
+        """)
+    end
+
+    body = JSON3.read(String(r.body))
+    # `GET /tokens` answers with an array, `POST /token` with a single object.
+    entry = body isa JSON3.Array ? (isempty(body) ? nothing : first(body)) : body
+    if isnothing(entry) || !haskey(entry, :access_token)
+        error("""
+        Earthdata Login returned no usable token. With `create=false` this means the
+        account currently holds none; call `token_from_netrc(create=true)` or create one
+        at $(token_page).
+        """)
+    end
+    return String(entry.access_token)
+end
+
+"""
+    netrc_credentials(machine="urs.earthdata.nasa.gov"; path=nothing) -> (login, password)
+
+Read `login` and `password` for `machine` from `.netrc`, the counterpart to
+[`netrc!`](@ref).
+
+`.netrc` is a whitespace-separated token stream, so the tokens are scanned in order and the
+values following the target `machine` are taken until the next `machine` or `default`
+entry. The `macdef` form is not supported. `path` defaults to `ENV["NETRC"]`, else
+`~/.netrc` (`~/_netrc` on Windows).
+"""
+function netrc_credentials(
+    machine::AbstractString="urs.earthdata.nasa.gov";
+    path=nothing,
+)
+    default_name = Sys.iswindows() ? "_netrc" : ".netrc"
+    file = something(path, get(ENV, "NETRC", joinpath(homedir(), default_name)))
+    isfile(file) || error("""
+        No .netrc file at $(file), so Earthdata Login credentials cannot be read.
+        Add a stanza:
+
+            machine $(machine) login YOUR_USERNAME password YOUR_PASSWORD
+
+        and `chmod 600` it, or use `EarthData.netrc!(username, password)`.
+        """)
+
+    tokens = split(read(file, String))
+    login = password = nothing
+    inside = false
+    i = 1
+    while i <= length(tokens)
+        t = tokens[i]
+        if t == "machine"
+            inside = i + 1 <= length(tokens) && tokens[i + 1] == machine
+            i += 2
+            continue
+        elseif t == "default"
+            inside = true
+            i += 1
+            continue
+        elseif inside && t in ("login", "password") && i + 1 <= length(tokens)
+            t == "login" ? (login = tokens[i + 1]) : (password = tokens[i + 1])
+            i += 2
+            !isnothing(login) && !isnothing(password) && break
+            continue
+        end
+        i += 1
+    end
+
+    (isnothing(login) || isnothing(password)) &&
+        error("$(file) has no login/password for machine \"$(machine)\".")
+    return String(login), String(password)
+end
+
+"""
+    auth_headers(; bearer=EarthData.token()) -> Vector{Pair{String,String}}
+
+`Authorization: Bearer` header for an Earthdata Login token, for clients that set their own
+headers rather than relying on `.netrc`.
+"""
+auth_headers(; bearer=token()) = ["Authorization" => "Bearer $(bearer)"]

--- a/test/auth.jl
+++ b/test/auth.jl
@@ -1,0 +1,125 @@
+using HTTP
+using JSON3
+
+@testset "Token resolution" begin
+    withenv("EARTHDATA_TOKEN" => "  tok-from-env  ") do
+        # The environment variable wins, and is stripped.
+        @test EarthData.token() == "tok-from-env"
+    end
+
+    mktempdir() do dir
+        # An empty variable is treated as absent, not as an empty token — otherwise a shell
+        # that exports it unset produces a 401 instead of a setup message.
+        withenv("EARTHDATA_TOKEN" => "", "HOME" => dir) do
+            @test_throws ErrorException EarthData.token()
+        end
+
+        write(joinpath(dir, ".edl_token"), "# my token\n\ntok-from-file\n")
+        withenv("EARTHDATA_TOKEN" => nothing, "HOME" => dir) do
+            @test EarthData.token() == "tok-from-file"
+        end
+    end
+
+    mktempdir() do dir
+        withenv("EARTHDATA_TOKEN" => nothing, "HOME" => dir) do
+            msg = try
+                EarthData.token()
+                ""
+            catch err
+                sprint(showerror, err)
+            end
+            # The message must name the token page and the two-token limit: requesting a
+            # third token is the most common first-run failure.
+            @test occursin(EarthData.token_page, msg)
+            @test occursin("two", msg)
+            @test occursin("EARTHDATA_TOKEN", msg)
+        end
+    end
+
+    @test EarthData.auth_headers(bearer="abc") == ["Authorization" => "Bearer abc"]
+end
+
+@testset ".netrc credentials" begin
+    mktempdir() do dir
+        path = joinpath(dir, "netrc")
+        write(
+            path,
+            """
+            machine example.com login wrong password wrong
+            machine urs.earthdata.nasa.gov
+                login someone
+                password s3cret
+            """,
+        )
+        @test EarthData.netrc_credentials("urs.earthdata.nasa.gov"; path) ==
+              ("someone", "s3cret")
+        # A machine with no credentials is an error, not a silent fall-through to the
+        # wrong stanza.
+        @test_throws ErrorException EarthData.netrc_credentials("nasa.example"; path)
+        @test_throws ErrorException EarthData.netrc_credentials(
+            "urs.earthdata.nasa.gov";
+            path=joinpath(dir, "absent"),
+        )
+
+        withenv("NETRC" => path) do
+            @test EarthData.netrc_credentials() == ("someone", "s3cret")
+        end
+    end
+end
+
+@testset "Token from .netrc" begin
+    mktempdir() do dir
+        path = joinpath(dir, "netrc")
+        write(path, "machine urs.earthdata.nasa.gov login someone password s3cret\n")
+
+        requests = []
+        function requester(method, url, headers; kwargs...)
+            push!(requests, (; method=String(method), url=String(url), headers))
+            return HTTP.Response(
+                200,
+                Pair{String,String}[];
+                body=JSON3.write([Dict("access_token" => "tok-from-edl")]),
+            )
+        end
+
+        withenv("NETRC" => path) do
+            @test EarthData.token_from_netrc(; requester) == "tok-from-edl"
+        end
+        # `create=false` must LIST tokens (GET /tokens), never create one: an account may
+        # hold only two, and a third request is refused.
+        @test only(requests).method == "GET"
+        @test endswith(only(requests).url, "/tokens")
+        @test any(
+            p -> String(p[1]) == "Authorization" && startswith(String(p[2]), "Basic "),
+            only(requests).headers,
+        )
+
+        empty!(requests)
+        creating(args...; kwargs...) = requester(args...; kwargs...)
+        withenv("NETRC" => path) do
+            EarthData.token_from_netrc(; create=true, requester=creating)
+        end
+        @test only(requests).method == "POST"
+        @test endswith(only(requests).url, "/token")
+
+        # An empty token list is an actionable error, not an empty string handed onward.
+        empty_list(args...; kwargs...) =
+            HTTP.Response(200, Pair{String,String}[]; body="[]")
+        withenv("NETRC" => path) do
+            @test_throws ErrorException EarthData.token_from_netrc(; requester=empty_list)
+        end
+
+        refused(args...; kwargs...) =
+            HTTP.Response(403, Pair{String,String}[]; body="max tokens")
+        withenv("NETRC" => path) do
+            msg = try
+                EarthData.token_from_netrc(; create=true, requester=refused)
+                ""
+            catch err
+                sprint(showerror, err)
+            end
+            @test occursin("403", msg)
+            @test occursin("two-token limit", msg)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Documenter
 include("schema_modules.jl")
 include("show.jl")
 include("search.jl")
+include("auth.jl")
 
 function setup_env()
     if "EARTHDATA_USER" in keys(ENV)


### PR DESCRIPTION
`netrc!` covers clients that let curl read `.netrc`. A client that sets its own headers needs the other credential EDL issues, a bearer token:

```julia
headers = EarthData.auth_headers()   # Authorization: Bearer <token>
```

New `src/auth.jl`:

- `token()` — resolves `ENV["EARTHDATA_TOKEN"]` → `~/.edl_token` → an error naming the token page. **Never touches the network**, so it is safe to call from a retry loop.
- `token_from_netrc(; create=false)` — obtains one from `.netrc` credentials. A separate, explicit network call.
- `netrc_credentials(machine)` — reads `.netrc`, the counterpart to `netrc!`.
- `auth_headers(; bearer=token())`.

The split between the last two is the design point: an account may hold at most **two** live tokens, and a third request 403s. So creation must not be reachable from a resolver. `create=false` only lists and cannot use up the quota.

Additive — `netrc!` and the curl path are untouched. Adds a `Base64` stdlib dep. Tests are offline via an injected `requester`.

Two open questions: is `~/.edl_token` the right file convention, and should `download` grow a `bearer=` keyword?