### PR TITLE
Split transient from permanent failures, and verify downloads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Aria2_jll = "9ab3bdc3-1250-5043-8fac-ac7e82d2cbc9"
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"

--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -43,6 +43,36 @@ https_urls(gg)
 s3_urls(gg)
 ```
 
+### Selecting the data file
+
+A record's related URLs are not all data. A single MCD43A3 granule, for example, carries
+eight: the HTTPS file, its S3 copy, a DOI landing page, a metadata sidecar, browse imagery
+and a cloud-credentials endpoint. `https_urls` returns most of those, so filter on
+`RelatedUrls[].Type` instead — `data_urls` does exactly that, keeping only `"GET DATA"`:
+
+```julia
+data_urls(first(gg))          # the file
+download(gg, "data"; type="GET DATA")
+```
+
+The S3 copy of the same file is typed `"GET DATA VIA DIRECT ACCESS"`:
+
+```julia
+urls(first(gg); scheme=:s3, type="GET DATA VIA DIRECT ACCESS")
+```
+
+### Granule sizes
+
+`granule_size` reports a granule's size in bytes:
+
+```julia
+granule_size(first(gg))
+```
+
+It prefers `SizeInBytes`, and otherwise converts `Size` using the record's `SizeUnit`.
+`Size` alone is unit-less — providers commonly report megabytes — so reading it without
+the unit understates the size by a factor of about a million.
+
 ## Earthdata credentials
 
 NASA Earthdata downloads require credentials. Store them in your `.netrc` file

--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -126,6 +126,39 @@ batch HTTPS downloads:
 download(gg, "data")
 ```
 
+### Verified downloads and retries
+
+`download_verified` downloads a granule's `"GET DATA"` file with a bearer token, retrying
+transient failures and checking the size it got against [`granule_size`](@ref):
+
+```julia
+download_verified(first(gg), "data")
+```
+
+Two things it does that a bare `download` does not:
+
+- It writes `path.part` and moves the file into place only once the size checks out. An
+  interrupted transfer therefore leaves nothing behind that looks complete — a truncated
+  HDF or NetCDF granule is only discovered when something opens it, and the reader's error
+  for that names neither the download nor the size.
+- It retries **5xx**, **408** and **429** and connection-level faults, and fails
+  immediately on **400**, **401**, **403** and **404**. Both halves matter: a single 502
+  should not discard an hours-long run, but a 403 from a DAAC means an end-user licence has
+  not been accepted, and retrying that loops until the deadline without ever succeeding.
+
+A server-supplied `Retry-After` overrides the backoff curve, capped at five minutes.
+`deadline` (an absolute `time()`) is what should normally bound the retrying — the attempt
+cap is set high enough to wait out a maintenance window.
+
+To apply the same classification to a search, wrap the requester:
+
+```julia
+granules(short_name="MCD43A3", version="061", requester=classifying_requester())
+```
+
+Without it a CMR 503 arrives as a generic `ErrorException` from `parse_cmr_error`, which is
+indistinguishable from a rejected query.
+
 To write a URL list for another tool:
 
 ```julia

--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -55,6 +55,31 @@ EarthData.netrc!("earthdata_username", "earthdata_password")
 The file is plaintext, so use the same care you would use for any credential
 file.
 
+### Bearer tokens
+
+Earthdata Login also issues bearer tokens, which is the credential an HTTP client
+needs when it sets its own headers rather than delegating to curl's `.netrc`
+support. `EarthData.token()` resolves one from `ENV["EARTHDATA_TOKEN"]`, else the
+first non-comment line of `~/.edl_token`, and `auth_headers` builds the header:
+
+```julia
+headers = EarthData.auth_headers()          # Authorization: Bearer <token>
+Downloads.download(data_urls(first(gg))[1], "granule.h5"; headers)
+```
+
+Resolution never touches the network. To obtain a token from your `.netrc`
+credentials instead, call `EarthData.token_from_netrc()` explicitly:
+
+```julia
+ENV["EARTHDATA_TOKEN"] = EarthData.token_from_netrc()
+```
+
+!!! warning "Two concurrent tokens, maximum"
+    An account may hold two live tokens; requesting a third returns HTTP 403.
+    `token_from_netrc()` lists existing tokens and returns the first, so it cannot
+    exhaust the quota; `token_from_netrc(create=true)` will consume a slot when the
+    account has none. Never call either from a retry loop. Tokens last 60 days.
+
 ## Downloading files
 
 Download one URL to a path:

--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -7,8 +7,10 @@ using JSON3
 using Extents
 using StructTypes
 import Downloads
+import Base64
 
 include("utils.jl")
+include("auth.jl")
 abstract type AbstractJSON end
 include("umm/granules.jl")
 include("umm/collections.jl")

--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -354,18 +354,29 @@ function scheme_prefix(scheme)
     endswith(s, ":") ? s : s * ":"
 end
 
-function urls(item::AbstractJSON; scheme=nothing)
+url_type(u) = hasproperty(u, :Type) ? getproperty(u, :Type) : nothing
+
+"""
+    urls(item; scheme=nothing, type=nothing) -> Vector{String}
+
+Related URLs of a UMM record, optionally filtered by URL `scheme` (`:https`, `:s3`) and by
+`RelatedUrls[].Type` (`"GET DATA"`, `"GET DATA VIA DIRECT ACCESS"`,
+`"VIEW RELATED INFORMATION"`, ...).
+"""
+function urls(item::AbstractJSON; scheme=nothing, type=nothing)
     related_urls = getproperty(item, :RelatedUrls)
     isnothing(related_urls) && return String[]
-    result = [u.URL for u in related_urls]
+    selected = related_urls
+    isnothing(type) || (selected = filter(u -> url_type(u) == type, selected))
+    result = [u.URL for u in selected]
     isnothing(scheme) && return result
     filter(startswith(scheme_prefix(scheme)), result)
 end
 
-function urls(items::AbstractVector{<:AbstractJSON}; scheme=nothing)
+function urls(items::AbstractVector{<:AbstractJSON}; scheme=nothing, type=nothing)
     result = String[]
     for item in items
-        append!(result, urls(item; scheme))
+        append!(result, urls(item; scheme, type))
     end
     return result
 end
@@ -373,35 +384,122 @@ end
 https_urls(item) = urls(item; scheme=:https)
 s3_urls(item) = urls(item; scheme=:s3)
 
-function download_url(item; scheme=:https)
-    candidates = urls(item; scheme)
+"""
+    data_urls(item; scheme=:https) -> Vector{String}
+
+URLs of the granule's data file(s), i.e. the related URLs typed `"GET DATA"`.
+
+Records commonly carry several related URLs that are not the data: a DOI landing page, a
+metadata sidecar, browse imagery, a cloud-credentials endpoint. Filtering on the scheme
+alone does not separate those from the file, so prefer this over [`https_urls`](@ref) when
+what you want is something to download. Note the S3 copy of the same file is typed
+`"GET DATA VIA DIRECT ACCESS"` and so is *not* returned; use
+`urls(item; scheme=:s3, type="GET DATA VIA DIRECT ACCESS")` for that.
+"""
+data_urls(item; scheme=:https) = urls(item; scheme, type="GET DATA")
+
+function download_url(item; scheme=:https, type=nothing)
+    candidates = urls(item; scheme, type)
     isempty(candidates) ? nothing : first(candidates)
 end
 
-function write_urls(io::IO, items::AbstractVector{<:AbstractJSON}; scheme=:https)
-    write_urls(io, urls(items; scheme))
+const size_unit_factors = Dict(
+    "BYTES" => 1,
+    "B" => 1,
+    "KB" => 1024,
+    "MB" => 1024^2,
+    "GB" => 1024^3,
+    "TB" => 1024^4,
+)
+
+"""
+    size_unit_factor(unit) -> Int
+
+Bytes per `unit`, for the `SizeUnit` values UMM allows (`"Bytes"`, `"KB"`, `"MB"`, `"GB"`,
+`"TB"`; binary multiples). Throws for an unrecognised unit rather than guessing, since a
+wrong factor silently misreports a size by three orders of magnitude.
+"""
+function size_unit_factor(unit::AbstractString)
+    key = uppercase(strip(unit))
+    haskey(size_unit_factors, key) ||
+        throw(ArgumentError("Unrecognised UMM SizeUnit: $(repr(unit))"))
+    return size_unit_factors[key]
+end
+
+"""
+    granule_size(granule; default_unit="MB") -> Union{Int,Nothing}
+
+Size of a granule in bytes, from `DataGranule.ArchiveAndDistributionInformation`, or
+`nothing` when the record does not report one.
+
+`SizeInBytes` is used when present. Otherwise `Size` is converted using its `SizeUnit` —
+`Size` is unit-less on its own, and providers do report units other than bytes, so reading
+the number without the unit is how a megabyte figure gets mistaken for a byte count. A
+record that gives `Size` with no `SizeUnit` is read as `default_unit`, which is what the
+DAACs mean in practice; pass `default_unit` explicitly if a provider differs.
+
+Sizes of multiple files are summed, since together they are the granule.
+"""
+function granule_size(granule::AbstractJSON; default_unit::AbstractString="MB")
+    data_granule = getproperty(granule, :DataGranule)
+    isnothing(data_granule) && return nothing
+    entries = getproperty(data_granule, :ArchiveAndDistributionInformation)
+    isnothing(entries) && return nothing
+    total = 0
+    found = false
+    for entry in entries
+        bytes = entry.SizeInBytes
+        if isnothing(bytes)
+            isnothing(entry.Size) && continue
+            unit = something(entry.SizeUnit, default_unit)
+            bytes = round(Int, entry.Size * size_unit_factor(unit))
+        end
+        total += bytes
+        found = true
+    end
+    return found ? total : nothing
+end
+
+function write_urls(
+    io::IO,
+    items::AbstractVector{<:AbstractJSON};
+    scheme=:https,
+    type=nothing,
+)
+    write_urls(io, urls(items; scheme, type))
 end
 
 function write_urls(
     fn::AbstractString,
     items::AbstractVector{<:AbstractJSON};
     scheme=:https,
+    type=nothing,
 )
-    write_urls(fn, urls(items; scheme))
+    write_urls(fn, urls(items; scheme, type))
 end
 
-function write_urls(items::AbstractVector{<:AbstractJSON}; scheme=:https)
-    write_urls(urls(items; scheme))
+function write_urls(items::AbstractVector{<:AbstractJSON}; scheme=:https, type=nothing)
+    write_urls(urls(items; scheme, type))
 end
 
 function download(
     items::AbstractVector{<:AbstractJSON},
     folder::AbstractString=".";
     scheme=:https,
+    type=nothing,
     kwargs...,
 )
-    download(urls(items; scheme), folder; kwargs...)
+    download(urls(items; scheme, type), folder; kwargs...)
 end
 
-export granules, collections, urls, https_urls, s3_urls, download_url, write_urls, download
+export granules,
+    collections,
+    urls,
+    https_urls,
+    s3_urls,
+    data_urls,
+    download_url,
+    granule_size,
+    write_urls,
+    download
 end

--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -17,6 +17,7 @@ include("umm/collections.jl")
 include("display.jl")
 include("show.jl")
 include("stub.jl")  # empty methods that are actually defined in extensions
+include("retry.jl")
 
 const world = Extent(X=(-180.0, 180.0), Y=(-90.0, 90.0))
 
@@ -503,5 +504,6 @@ export granules,
     download_url,
     granule_size,
     write_urls,
-    download
+    download,
+    download_verified
 end

--- a/src/auth.jl
+++ b/src/auth.jl
@@ -1,0 +1,175 @@
+"""
+Earthdata Login (EDL) bearer tokens.
+
+`netrc!` writes a username and password for tools that speak `.netrc`. A bearer token is
+the other credential EDL issues, and it is what an HTTP client needs when it sets its own
+headers — `Authorization: Bearer <token>` — rather than delegating to curl's netrc support.
+
+Resolution ([`token`](@ref)) is deliberately offline. Obtaining a token
+([`token_from_netrc`](@ref)) is a separate, explicit call, because an account may hold only
+**two** live tokens and creation must never be reachable from a retry loop.
+"""
+
+const token_page = "https://urs.earthdata.nasa.gov/users/tokens"
+const token_api = "https://urs.earthdata.nasa.gov/api/users"
+
+"""
+    token() -> String
+
+The Earthdata Login bearer token, from the environment or a token file.
+
+Searches, in order:
+
+1. `ENV["EARTHDATA_TOKEN"]`
+2. `~/.edl_token` (first non-empty, non-comment line)
+
+Throws an `ErrorException` with setup instructions when neither is present.
+
+This never contacts the network. To obtain a token from `.netrc` credentials instead, call
+[`token_from_netrc`](@ref) explicitly.
+
+`EARTHDATA_TOKEN` is a community convention rather than a NASA-defined variable; no NASA
+tooling reads it for you.
+
+Treat the returned string as a secret: it authenticates as the account for 60 days.
+"""
+function token()
+    tok = get(ENV, "EARTHDATA_TOKEN", "")
+    isempty(strip(tok)) || return String(strip(tok))
+
+    path = joinpath(homedir(), ".edl_token")
+    if isfile(path)
+        for line in readlines(path)
+            s = strip(line)
+            (isempty(s) || startswith(s, "#")) && continue
+            return String(s)
+        end
+    end
+
+    error("""
+    No NASA Earthdata Login token found. Create one at
+        $(token_page)
+    and either
+
+        export EARTHDATA_TOKEN="your-token-here"
+
+    or write it to ~/.edl_token. A token lasts 60 days, and an account may hold at most
+    two at a time — reuse an existing one rather than requesting a third, which fails.
+
+    Alternatively, with ~/.netrc credentials for urs.earthdata.nasa.gov in place:
+        EarthData.token_from_netrc()
+    """)
+end
+
+"""
+    token_from_netrc(; create=false, machine="urs.earthdata.nasa.gov") -> String
+
+Fetch an Earthdata Login bearer token using the username and password stored in `.netrc`.
+
+This is a network call, kept out of [`token`](@ref) on purpose: a credential lookup that
+can hit the network is a lookup that can hang or rate-limit inside a retry loop.
+
+!!! warning "Two concurrent tokens, maximum"
+    EDL allows an account two live tokens; requesting a third returns HTTP 403. With
+    `create=false` (the default) this only *lists* tokens and returns the first, so it
+    cannot exhaust the quota. `create=true` will consume the second slot when none exists.
+    Do not call this from a retry loop.
+"""
+function token_from_netrc(;
+    create::Bool=false,
+    machine::AbstractString="urs.earthdata.nasa.gov",
+    requester=HTTP.request,
+)
+    user, pass = netrc_credentials(machine)
+    auth = "Basic " * Base64.base64encode(string(user, ":", pass))
+    headers = ["Authorization" => auth, "Accept" => "application/json"]
+
+    endpoint = create ? "$(token_api)/token" : "$(token_api)/tokens"
+    method = create ? "POST" : "GET"
+    r = requester(method, endpoint, headers; status_exception=false)
+    if r.status >= 400
+        error("""
+        Earthdata Login rejected the token request ($(method) $(endpoint), HTTP $(r.status)):
+
+        $(String(r.body))
+
+        HTTP 401 means the .netrc credentials for "$(machine)" are wrong. HTTP 403 on a
+        creation request usually means the two-token limit is already reached — list them
+        at $(token_page) and reuse one.
+        """)
+    end
+
+    body = JSON3.read(String(r.body))
+    # `GET /tokens` answers with an array, `POST /token` with a single object.
+    entry = body isa JSON3.Array ? (isempty(body) ? nothing : first(body)) : body
+    if isnothing(entry) || !haskey(entry, :access_token)
+        error("""
+        Earthdata Login returned no usable token. With `create=false` this means the
+        account currently holds none; call `token_from_netrc(create=true)` or create one
+        at $(token_page).
+        """)
+    end
+    return String(entry.access_token)
+end
+
+"""
+    netrc_credentials(machine="urs.earthdata.nasa.gov"; path=nothing) -> (login, password)
+
+Read `login` and `password` for `machine` from `.netrc`, the counterpart to
+[`netrc!`](@ref).
+
+`.netrc` is a whitespace-separated token stream, so the tokens are scanned in order and the
+values following the target `machine` are taken until the next `machine` or `default`
+entry. The `macdef` form is not supported. `path` defaults to `ENV["NETRC"]`, else
+`~/.netrc` (`~/_netrc` on Windows).
+"""
+function netrc_credentials(
+    machine::AbstractString="urs.earthdata.nasa.gov";
+    path=nothing,
+)
+    default_name = Sys.iswindows() ? "_netrc" : ".netrc"
+    file = something(path, get(ENV, "NETRC", joinpath(homedir(), default_name)))
+    isfile(file) || error("""
+        No .netrc file at $(file), so Earthdata Login credentials cannot be read.
+        Add a stanza:
+
+            machine $(machine) login YOUR_USERNAME password YOUR_PASSWORD
+
+        and `chmod 600` it, or use `EarthData.netrc!(username, password)`.
+        """)
+
+    tokens = split(read(file, String))
+    login = password = nothing
+    inside = false
+    i = 1
+    while i <= length(tokens)
+        t = tokens[i]
+        if t == "machine"
+            inside = i + 1 <= length(tokens) && tokens[i + 1] == machine
+            i += 2
+            continue
+        elseif t == "default"
+            inside = true
+            i += 1
+            continue
+        elseif inside && t in ("login", "password") && i + 1 <= length(tokens)
+            t == "login" ? (login = tokens[i + 1]) : (password = tokens[i + 1])
+            i += 2
+            !isnothing(login) && !isnothing(password) && break
+            continue
+        end
+        i += 1
+    end
+
+    (isnothing(login) || isnothing(password)) &&
+        error("$(file) has no login/password for machine \"$(machine)\".")
+    return String(login), String(password)
+end
+
+"""
+    auth_headers(; bearer=EarthData.token()) -> Vector{Pair{String,String}}
+
+`Authorization: Bearer` header for an Earthdata Login token, for clients that set their own
+headers rather than relying on `.netrc`.
+"""
+auth_headers(; bearer=token()) = ["Authorization" => "Bearer $(bearer)"]

--- a/src/retry.jl
+++ b/src/retry.jl
@@ -1,0 +1,305 @@
+"""
+Retry policy for Earthdata and CMR requests.
+
+The transient/permanent split matters in both directions, and getting it wrong is expensive
+either way: retrying a permanent error produces an endless request loop, while failing fast
+on a service hiccup discards however much work a run had already done.
+
+Transient — the service said nothing about the request:
+
+- **5xx**, plus **408** and **429** (a legal request, and the service asking us to come
+  back later).
+- Connection-level faults: DNS, connect, timeout, reset, truncated body.
+
+Permanent — retrying cannot help:
+
+- **401** — the bearer token is missing, malformed or expired (they last 60 days).
+- **403** — the token is valid but the account has not accepted the collection's licence or
+  approved the DAAC application. No amount of waiting fixes this.
+- **404** — the granule is not there.
+- **400** — the query is wrong.
+"""
+
+# The attempt cap must not be the binding limit; a caller's `deadline` should be. A download
+# is minutes of work, so a maintenance window is worth waiting out rather than discarding.
+const retry_base = 2.0
+const retry_max_backoff = 60.0
+const retry_attempts = 60
+
+const transient_statuses = (408, 429, 500, 502, 503, 504)
+
+# Cap on an honoured `Retry-After`, so a pathological header cannot park a run for hours.
+const retry_after_max = 300.0
+
+"""
+    TransientError(context, status, detail, retry_after=0.0)
+
+An Earthdata or CMR response that says nothing about the request: a 5xx, or a 408/429. See
+the module docstring for why this is distinguished from 401/403/404.
+"""
+struct TransientError <: Exception
+    context::String
+    status::Int
+    detail::String
+    retry_after::Float64   # server-requested wait in seconds; 0.0 when unspecified
+end
+
+TransientError(context, status, detail) = TransientError(context, status, detail, 0.0)
+
+function Base.showerror(io::IO, e::TransientError)
+    print(
+        io,
+        """
+        Earthdata server error ($(e.context), HTTP $(e.status)).
+
+        $(e.detail)
+
+        This is a service-side fault rather than a problem with the request, and is
+        normally transient.
+        """,
+    )
+end
+
+"""
+    retry_after_seconds(response) -> Float64
+
+Seconds the server asked us to wait, from `Retry-After`, or `0.0` when the header is absent
+or unparseable. Only the delta-seconds form is honoured; clamped to `retry_after_max`.
+"""
+function retry_after_seconds(response)
+    raw = HTTP.header(response, "Retry-After", "")
+    isempty(strip(raw)) && return 0.0
+    seconds = tryparse(Float64, strip(raw))
+    isnothing(seconds) && return 0.0
+    return clamp(seconds, 0.0, retry_after_max)
+end
+
+"""
+    is_transient(err) -> Bool
+
+Whether `err` is worth retrying. Deliberately narrow: a [`TransientError`](@ref) or a
+connection-level failure. `ArgumentError` (a permanent status, a bad query) and plain
+`ErrorException` (a size mismatch, a missing link) are not transient.
+"""
+is_transient(err) =
+    err isa TransientError ||
+    err isa HTTP.Exceptions.ConnectError ||
+    err isa HTTP.Exceptions.TimeoutError ||
+    err isa HTTP.Exceptions.RequestError ||
+    err isa Downloads.RequestError ||
+    err isa Base.IOError ||
+    err isa EOFError
+
+# Response bodies can be a full HTML error page; keep the message readable.
+function body_excerpt(r; limit::Integer=800)
+    body = try
+        String(r.body)
+    catch
+        ""
+    end
+    s = strip(body)
+    isempty(s) && return "(empty response body)"
+    return length(s) <= limit ? s : string(first(s, limit), "\n… (truncated)")
+end
+
+"""
+    check_response(r, context)
+
+Throw for an error response: [`TransientError`](@ref) for a retryable status, an
+`ArgumentError` carrying actionable advice for a permanent one. Returns `nothing` on
+success.
+"""
+function check_response(r, context::AbstractString)
+    r.status < 400 && return nothing
+    detail = body_excerpt(r)
+    if r.status in transient_statuses || r.status >= 500
+        throw(TransientError(context, r.status, detail, retry_after_seconds(r)))
+    elseif r.status == 401
+        throw(
+            ArgumentError(
+                """
+                Earthdata Login rejected the token ($(context), HTTP 401).
+
+                $(detail)
+
+                Tokens expire after 60 days. Check EARTHDATA_TOKEN, or list/create one at
+                $(token_page).
+                """,
+            ),
+        )
+    elseif r.status == 403
+        throw(
+            ArgumentError(
+                """
+                Earthdata accepted the token but refused the request ($(context), HTTP 403).
+
+                $(detail)
+
+                This is almost always an unaccepted end-user licence or an unapproved
+                application rather than a bad token — log in at
+                https://urs.earthdata.nasa.gov/ and approve the DAAC application, then
+                retry. Retrying without doing so cannot help.
+                """,
+            ),
+        )
+    else
+        throw(
+            ArgumentError(
+                """
+                Earthdata request failed ($(context), HTTP $(r.status)).
+
+                $(detail)
+                """,
+            ),
+        )
+    end
+end
+
+"""
+    with_retries(f; context, attempts=retry_attempts, verbose=true, deadline=Inf) -> f()
+
+Call `f`, retrying while it fails transiently (see [`is_transient`](@ref)) with exponential
+backoff from `retry_base` to `retry_max_backoff`. Non-transient errors propagate on the
+first attempt, unchanged, and the final failure is rethrown rather than wrapped so the
+message the user sees is the service's own.
+
+`deadline` is an absolute `time()` value bounding the retrying, and it — not `attempts` —
+is what should normally bind. A server-supplied `Retry-After` overrides the backoff curve
+upward; the service knows better than we do.
+"""
+function with_retries(
+    f;
+    context::AbstractString,
+    attempts::Integer=retry_attempts,
+    verbose::Bool=true,
+    deadline::Float64=Inf,
+)
+    attempt = 0
+    while true
+        attempt += 1
+        try
+            return f()
+        catch err
+            (is_transient(err) && attempt < attempts) || rethrow()
+            backoff = min(retry_base * 2.0^(attempt - 1), retry_max_backoff)
+            requested = err isa TransientError ? err.retry_after : 0.0
+            requested > 0 && (backoff = max(backoff, requested))
+            time() + backoff >= deadline && rethrow()
+            verbose && @warn "Transient Earthdata failure; retrying" context attempt backoff_s =
+                round(backoff; digits=1) error = sprint(showerror, err)
+            sleep(backoff)
+        end
+    end
+end
+
+"""
+    classifying_requester(inner=HTTP.request, context="CMR search")
+
+Wrap a `requester` (as accepted by [`request`](@ref), [`granules`](@ref) and
+[`collections`](@ref)) so a transient status throws [`TransientError`](@ref) instead of
+being turned into a plain `ErrorException` by `parse_cmr_error`.
+
+Only transient statuses are intercepted; permanent ones are handed back untouched so
+`parse_cmr_error`'s reading of CMR's `errors` array is what the caller sees.
+
+```julia
+granules(
+    short_name="MCD43A3",
+    version="061",
+    requester=classifying_requester(),
+)
+```
+"""
+function classifying_requester(inner=HTTP.request, context::AbstractString="CMR search")
+    return function (args...; kwargs...)
+        r = inner(args...; kwargs...)
+        if r.status in transient_statuses || r.status >= 500
+            throw(TransientError(context, r.status, body_excerpt(r), retry_after_seconds(r)))
+        end
+        return r
+    end
+end
+
+# Tolerance on a CMR-reported size, as a fraction. `granule_size` can be a rounded megabyte
+# figure, so it cannot be compared exactly; wide enough to absorb the rounding and narrow
+# enough to catch a truncated transfer.
+const size_tolerance = 0.01
+
+"""
+    download_verified(url, path; bearer=token(), expected_bytes=0, verbose=true,
+                      deadline=Inf) -> path
+
+Download `url` to `path` with an Earthdata Login bearer token, retrying transient failures.
+
+Writes to `path * ".part"` and moves it into place on success, so an interrupted transfer
+never leaves a plausible-looking truncated file behind. When `expected_bytes > 0` (pass
+[`granule_size`](@ref)) the final size is checked against it within `size_tolerance`; a
+short file is treated as a transient failure and re-downloaded, because a truncated HDF or
+NetCDF granule fails much later and far less legibly than a failed download does.
+
+An existing `path` is returned untouched.
+
+!!! note "The bearer header survives the redirect"
+    LP DAAC answers a bearer-authenticated GET with a 303 to CloudFront, and
+    `Downloads.download` follows it and returns the full body — measured, with and without
+    the header forwarded. The presigned-URL/`Authorization` conflict that affects some S3
+    endpoints does not arise on this path.
+"""
+function download_verified(
+    url::AbstractString,
+    path::AbstractString;
+    bearer=token(),
+    expected_bytes::Integer=0,
+    verbose::Bool=true,
+    deadline::Float64=Inf,
+    downloader=Downloads.download,
+)
+    isfile(path) && return path
+    mkpath(dirname(abspath(path)))
+    tmp = path * ".part"
+    headers = auth_headers(; bearer)
+    context = "download $(basename(path))"
+
+    try
+        with_retries(; context, verbose, deadline) do
+            isfile(tmp) && rm(tmp; force=true)
+            downloader(url, tmp; headers)
+            n = filesize(tmp)
+            if expected_bytes > 0 && n < expected_bytes * (1 - size_tolerance)
+                # Retryable: a short body is a cut-off transfer, not a bad request.
+                throw(
+                    TransientError(
+                        context,
+                        0,
+                        "Got $(n) bytes, expected ≈$(expected_bytes) — transfer was truncated.",
+                    ),
+                )
+            end
+            return nothing
+        end
+        mv(tmp, path; force=true)
+    catch
+        isfile(tmp) && rm(tmp; force=true)
+        rethrow()
+    end
+    return path
+end
+
+"""
+    download_verified(granule, folder="."; kwargs...) -> path
+
+Download a granule's `"GET DATA"` file into `folder`, verifying its size against
+[`granule_size`](@ref).
+"""
+function download_verified(
+    granule::AbstractJSON,
+    folder::AbstractString=".";
+    kwargs...,
+)
+    url = download_url(granule; type="GET DATA")
+    isnothing(url) &&
+        error("Granule has no \"GET DATA\" URL to download: $(urls(granule))")
+    path = joinpath(folder, url_filename(url))
+    expected = something(granule_size(granule), 0)
+    return download_verified(url, path; expected_bytes=expected, kwargs...)
+end

--- a/test/auth.jl
+++ b/test/auth.jl
@@ -1,0 +1,125 @@
+using HTTP
+using JSON3
+
+@testset "Token resolution" begin
+    withenv("EARTHDATA_TOKEN" => "  tok-from-env  ") do
+        # The environment variable wins, and is stripped.
+        @test EarthData.token() == "tok-from-env"
+    end
+
+    mktempdir() do dir
+        # An empty variable is treated as absent, not as an empty token — otherwise a shell
+        # that exports it unset produces a 401 instead of a setup message.
+        withenv("EARTHDATA_TOKEN" => "", "HOME" => dir) do
+            @test_throws ErrorException EarthData.token()
+        end
+
+        write(joinpath(dir, ".edl_token"), "# my token\n\ntok-from-file\n")
+        withenv("EARTHDATA_TOKEN" => nothing, "HOME" => dir) do
+            @test EarthData.token() == "tok-from-file"
+        end
+    end
+
+    mktempdir() do dir
+        withenv("EARTHDATA_TOKEN" => nothing, "HOME" => dir) do
+            msg = try
+                EarthData.token()
+                ""
+            catch err
+                sprint(showerror, err)
+            end
+            # The message must name the token page and the two-token limit: requesting a
+            # third token is the most common first-run failure.
+            @test occursin(EarthData.token_page, msg)
+            @test occursin("two", msg)
+            @test occursin("EARTHDATA_TOKEN", msg)
+        end
+    end
+
+    @test EarthData.auth_headers(bearer="abc") == ["Authorization" => "Bearer abc"]
+end
+
+@testset ".netrc credentials" begin
+    mktempdir() do dir
+        path = joinpath(dir, "netrc")
+        write(
+            path,
+            """
+            machine example.com login wrong password wrong
+            machine urs.earthdata.nasa.gov
+                login someone
+                password s3cret
+            """,
+        )
+        @test EarthData.netrc_credentials("urs.earthdata.nasa.gov"; path) ==
+              ("someone", "s3cret")
+        # A machine with no credentials is an error, not a silent fall-through to the
+        # wrong stanza.
+        @test_throws ErrorException EarthData.netrc_credentials("nasa.example"; path)
+        @test_throws ErrorException EarthData.netrc_credentials(
+            "urs.earthdata.nasa.gov";
+            path=joinpath(dir, "absent"),
+        )
+
+        withenv("NETRC" => path) do
+            @test EarthData.netrc_credentials() == ("someone", "s3cret")
+        end
+    end
+end
+
+@testset "Token from .netrc" begin
+    mktempdir() do dir
+        path = joinpath(dir, "netrc")
+        write(path, "machine urs.earthdata.nasa.gov login someone password s3cret\n")
+
+        requests = []
+        function requester(method, url, headers; kwargs...)
+            push!(requests, (; method=String(method), url=String(url), headers))
+            return HTTP.Response(
+                200,
+                Pair{String,String}[];
+                body=JSON3.write([Dict("access_token" => "tok-from-edl")]),
+            )
+        end
+
+        withenv("NETRC" => path) do
+            @test EarthData.token_from_netrc(; requester) == "tok-from-edl"
+        end
+        # `create=false` must LIST tokens (GET /tokens), never create one: an account may
+        # hold only two, and a third request is refused.
+        @test only(requests).method == "GET"
+        @test endswith(only(requests).url, "/tokens")
+        @test any(
+            p -> String(p[1]) == "Authorization" && startswith(String(p[2]), "Basic "),
+            only(requests).headers,
+        )
+
+        empty!(requests)
+        creating(args...; kwargs...) = requester(args...; kwargs...)
+        withenv("NETRC" => path) do
+            EarthData.token_from_netrc(; create=true, requester=creating)
+        end
+        @test only(requests).method == "POST"
+        @test endswith(only(requests).url, "/token")
+
+        # An empty token list is an actionable error, not an empty string handed onward.
+        empty_list(args...; kwargs...) =
+            HTTP.Response(200, Pair{String,String}[]; body="[]")
+        withenv("NETRC" => path) do
+            @test_throws ErrorException EarthData.token_from_netrc(; requester=empty_list)
+        end
+
+        refused(args...; kwargs...) =
+            HTTP.Response(403, Pair{String,String}[]; body="max tokens")
+        withenv("NETRC" => path) do
+            msg = try
+                EarthData.token_from_netrc(; create=true, requester=refused)
+                ""
+            catch err
+                sprint(showerror, err)
+            end
+            @test occursin("403", msg)
+            @test occursin("two-token limit", msg)
+        end
+    end
+end

--- a/test/retry.jl
+++ b/test/retry.jl
@@ -1,0 +1,257 @@
+using HTTP
+using Test
+
+@testset "Transient/permanent split" begin
+    # 5xx and the two "come back later" 4xx codes are the service saying nothing about the
+    # request, so they are worth retrying.
+    for status in (408, 429, 500, 502, 503, 504)
+        r = HTTP.Response(status, [], "boom")
+        @test_throws EarthData.TransientError EarthData.check_response(r, "test")
+    end
+
+    # A permanent status must fail on the first attempt: retrying a 403 EULA refusal loops
+    # until the deadline and never succeeds.
+    for status in (400, 401, 403, 404)
+        r = HTTP.Response(status, [], "nope")
+        @test_throws ArgumentError EarthData.check_response(r, "test")
+    end
+
+    @test EarthData.check_response(HTTP.Response(200, [], "ok"), "test") === nothing
+    @test EarthData.check_response(HTTP.Response(303, [], ""), "test") === nothing
+
+    # The messages have to name the fix, since neither status is self-explanatory to someone
+    # who has a working token in hand.
+    e401 = try
+        EarthData.check_response(HTTP.Response(401, [], "expired"), "download")
+        nothing
+    catch err
+        err
+    end
+    @test occursin("EARTHDATA_TOKEN", e401.msg)
+    @test occursin("60 days", e401.msg)
+
+    e403 = try
+        EarthData.check_response(HTTP.Response(403, [], "forbidden"), "download")
+        nothing
+    catch err
+        err
+    end
+    @test occursin("licence", e403.msg)
+    @test occursin("Retrying without doing so cannot help", e403.msg)
+
+    @test EarthData.is_transient(EarthData.TransientError("c", 503, "d"))
+    @test !EarthData.is_transient(ArgumentError("permanent"))
+    @test !EarthData.is_transient(ErrorException("size mismatch"))
+end
+
+@testset "Retry-After" begin
+    @test EarthData.retry_after_seconds(HTTP.Response(429, [], "")) == 0.0
+    @test EarthData.retry_after_seconds(HTTP.Response(429, ["Retry-After" => "12"], "")) ==
+          12.0
+    # A pathological header must not park a run for hours.
+    @test EarthData.retry_after_seconds(
+        HTTP.Response(429, ["Retry-After" => "99999"], ""),
+    ) == EarthData.retry_after_max
+    # The HTTP-date form is not parsed; falling back to the backoff curve is safe.
+    @test EarthData.retry_after_seconds(
+        HTTP.Response(429, ["Retry-After" => "Wed, 21 Oct 2015 07:28:00 GMT"], ""),
+    ) == 0.0
+
+    r = HTTP.Response(503, ["Retry-After" => "7"], "down")
+    err = try
+        EarthData.check_response(r, "test")
+        nothing
+    catch e
+        e
+    end
+    @test err.retry_after == 7.0
+end
+
+@testset "with_retries" begin
+    # A transient failure is retried; `attempts` bounds it.
+    calls = Ref(0)
+    result = EarthData.with_retries(; context="test", verbose=false) do
+        calls[] += 1
+        calls[] < 3 && throw(EarthData.TransientError("test", 503, "down", 0.0))
+        return :ok
+    end
+    @test result == :ok
+    @test calls[] == 3
+
+    # A permanent error propagates on the first attempt, unchanged.
+    calls[] = 0
+    @test_throws ArgumentError EarthData.with_retries(; context="test", verbose=false) do
+        calls[] += 1
+        throw(ArgumentError("permanent"))
+    end
+    @test calls[] == 1
+
+    # An already-passed deadline stops the retrying rather than sleeping into it.
+    calls[] = 0
+    @test_throws EarthData.TransientError EarthData.with_retries(;
+        context="test",
+        verbose=false,
+        deadline=time() - 1,
+    ) do
+        calls[] += 1
+        throw(EarthData.TransientError("test", 503, "down", 0.0))
+    end
+    @test calls[] == 1
+
+    # The attempt cap must not be the limit that normally binds: at the maximum backoff it
+    # has to outlast a maintenance window, leaving `deadline` in charge.
+    @test EarthData.retry_attempts * EarthData.retry_max_backoff >= 3600
+
+    @test sprint(showerror, EarthData.TransientError("ctx", 502, "gateway")) |>
+          s -> occursin("502", s) && occursin("ctx", s)
+end
+
+@testset "classifying_requester" begin
+    # A CMR 503 should be retryable rather than collapsed into parse_cmr_error's generic
+    # ErrorException.
+    inner = (args...; kwargs...) -> HTTP.Response(503, [], "CMR is down")
+    @test_throws EarthData.TransientError EarthData.classifying_requester(inner)(
+        "POST",
+        "https://example.test",
+        [],
+    )
+
+    # A permanent status is handed back untouched, so `parse_cmr_error` still reports CMR's
+    # own `errors` array.
+    body = JSON3.write(Dict("errors" => ["Parameter [nope] was not recognized."]))
+    permanent = (args...; kwargs...) -> HTTP.Response(400, [], body)
+    r = EarthData.classifying_requester(permanent)("POST", "https://example.test", [])
+    @test r.status == 400
+
+    requests = []
+    responses = [HTTP.Response(200, [], cmr_response(["G1"], "granule"))]
+    gg = EarthData.request(
+        "https://example.test/granules",
+        Dict("short_name" => "TEST"),
+        EarthData.Granules.UMM_G;
+        requester=EarthData.classifying_requester(
+            recording_requester(responses, requests),
+        ),
+    )
+    @test length(gg) == 1
+    @test length(requests) == 1
+end
+
+@testset "Verified download" begin
+    folder = mktempdir()
+
+    # The happy path: a full-size body lands at `path` and no `.part` survives.
+    path = joinpath(folder, "full.h5")
+    n = 4096
+    EarthData.download_verified(
+        "https://example.test/full.h5",
+        path;
+        bearer="fake-token",
+        expected_bytes=n,
+        verbose=false,
+        downloader=(url, dest; headers) -> write(dest, zeros(UInt8, n)),
+    )
+    @test filesize(path) == n
+    @test !isfile(path * ".part")
+
+    # The bearer header has to reach the downloader, since that is the whole point of the
+    # method existing alongside the netrc path.
+    seen = Ref{Any}(nothing)
+    EarthData.download_verified(
+        "https://example.test/hdr.h5",
+        joinpath(folder, "hdr.h5");
+        bearer="fake-token",
+        verbose=false,
+        downloader=(url, dest; headers) -> (seen[] = headers; write(dest, "x")),
+    )
+    @test ("Authorization" => "Bearer fake-token") in seen[]
+
+    # A truncated 200 is transient, not permanent: retrying is what recovers it. Left
+    # unchecked, the short file would be opened later and GDAL's message for a corrupt HDF4
+    # file names neither the download nor the size.
+    attempts = Ref(0)
+    short_path = joinpath(folder, "short.h5")
+    EarthData.download_verified(
+        "https://example.test/short.h5",
+        short_path;
+        bearer="fake-token",
+        expected_bytes=n,
+        verbose=false,
+        downloader=(url, dest; headers) -> begin
+            attempts[] += 1
+            write(dest, zeros(UInt8, attempts[] == 1 ? 10 : n))
+        end,
+    )
+    @test attempts[] == 2
+    @test filesize(short_path) == n
+
+    # A size within tolerance passes: `granule_size` can be a rounded megabyte figure, so an
+    # exact comparison would reject good files.
+    tol_path = joinpath(folder, "tol.h5")
+    EarthData.download_verified(
+        "https://example.test/tol.h5",
+        tol_path;
+        bearer="fake-token",
+        expected_bytes=1000,
+        verbose=false,
+        downloader=(url, dest; headers) -> write(dest, zeros(UInt8, 995)),
+    )
+    @test filesize(tol_path) == 995
+
+    # A failure leaves no partial file behind to be mistaken for a complete one.
+    fail_path = joinpath(folder, "fail.h5")
+    @test_throws ArgumentError EarthData.download_verified(
+        "https://example.test/fail.h5",
+        fail_path;
+        bearer="fake-token",
+        verbose=false,
+        downloader=(url, dest; headers) -> begin
+            write(dest, "partial")
+            throw(ArgumentError("permanent"))
+        end,
+    )
+    @test !isfile(fail_path)
+    @test !isfile(fail_path * ".part")
+
+    # An existing file is not re-downloaded.
+    calls = Ref(0)
+    EarthData.download_verified(
+        "https://example.test/full.h5",
+        path;
+        bearer="fake-token",
+        verbose=false,
+        downloader=(url, dest; headers) -> (calls[] += 1),
+    )
+    @test calls[] == 0
+end
+
+@testset "Verified download of a granule" begin
+    requests = []
+    responses = [HTTP.Response(200, [], cmr_response(["G1"], "granule"))]
+    granule = only(
+        EarthData.request(
+            "https://example.test/granules",
+            Dict("short_name" => "TEST"),
+            EarthData.Granules.UMM_G;
+            requester=recording_requester(responses, requests),
+        ),
+    )
+
+    folder = mktempdir()
+    expected = EarthData.granule_size(granule)
+    seen_url = Ref("")
+    path = EarthData.download_verified(
+        granule,
+        folder;
+        bearer="fake-token",
+        verbose=false,
+        downloader=(url, dest; headers) ->
+            (seen_url[] = url; write(dest, zeros(UInt8, expected))),
+    )
+
+    # The `GET DATA` URL is the one fetched — not the S3 copy, and not the credentials
+    # endpoint that an unfiltered HTTPS pick would return.
+    @test seen_url[] == "https://example.test/G1.h5"
+    @test path == joinpath(folder, "G1.h5")
+    @test filesize(path) == expected
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ include("schema_modules.jl")
 include("show.jl")
 include("search.jl")
 include("auth.jl")
+include("retry.jl")
 
 function setup_env()
     if "EARTHDATA_USER" in keys(ENV)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Documenter
 include("schema_modules.jl")
 include("show.jl")
 include("search.jl")
+include("auth.jl")
 
 function setup_env()
     if "EARTHDATA_USER" in keys(ENV)

--- a/test/search.jl
+++ b/test/search.jl
@@ -19,8 +19,23 @@ function granule_umm(id)
         "GranuleUR" => id,
         "RelatedUrls" => [
             Dict("URL" => "https://example.test/$id.h5", "Type" => "GET DATA"),
-            Dict("URL" => "s3://example-bucket/$id.h5", "Type" => "GET DATA"),
+            # A real record types the S3 copy of the same file separately, and carries
+            # several URLs that are not the data at all.
+            Dict(
+                "URL" => "s3://example-bucket/$id.h5",
+                "Type" => "GET DATA VIA DIRECT ACCESS",
+            ),
+            Dict(
+                "URL" => "https://example.test/s3credentials",
+                "Type" => "VIEW RELATED INFORMATION",
+            ),
         ],
+        "DataGranule" => Dict(
+            "DayNightFlag" => "DAY",
+            "ProductionDateTime" => "2020-01-01T00:00:00Z",
+            "ArchiveAndDistributionInformation" =>
+                [Dict("Name" => "$id.h5", "Size" => 1.5, "SizeUnit" => "MB")],
+        ),
         "MetadataSpecification" =>
             Dict("URL" => "https://example.test", "Version" => "1.6.6", "Name" => "UMM-G"),
         "ProviderDates" => [Dict("Type" => "Insert", "Date" => "2020-01-01T00:00:00Z")],
@@ -46,6 +61,10 @@ function collection_umm(id)
         "Abstract" => "Test collection",
         "DOI" => Dict(),
     )
+end
+
+struct SizelessItem <: EarthData.AbstractJSON
+    DataGranule::Nothing
 end
 
 function cmr_response(ids, concept_type; hits=length(ids))
@@ -167,15 +186,60 @@ end
         ),
     )
 
-    @test EarthData.urls(granule) ==
-          ["https://example.test/G1.h5", "s3://example-bucket/G1.h5"]
-    @test EarthData.urls(granule; scheme=:https) == ["https://example.test/G1.h5"]
-    @test EarthData.https_urls(granule) == ["https://example.test/G1.h5"]
+    @test EarthData.urls(granule) == [
+        "https://example.test/G1.h5",
+        "s3://example-bucket/G1.h5",
+        "https://example.test/s3credentials",
+    ]
+    @test EarthData.urls(granule; scheme=:https) ==
+          ["https://example.test/G1.h5", "https://example.test/s3credentials"]
+    @test EarthData.https_urls(granule) ==
+          ["https://example.test/G1.h5", "https://example.test/s3credentials"]
     @test EarthData.s3_urls(granule) == ["s3://example-bucket/G1.h5"]
     @test EarthData.download_url(granule; scheme=:https) == "https://example.test/G1.h5"
     @test EarthData.download_url(granule; scheme=:ftp) === nothing
     @test EarthData.urls([granule, granule]; scheme=:s3) ==
           ["s3://example-bucket/G1.h5", "s3://example-bucket/G1.h5"]
+
+    # Filtering on the scheme alone keeps the credentials endpoint; filtering on the type
+    # is what isolates the file.
+    @test EarthData.data_urls(granule) == ["https://example.test/G1.h5"]
+    @test EarthData.urls(granule; type="GET DATA VIA DIRECT ACCESS") ==
+          ["s3://example-bucket/G1.h5"]
+    @test EarthData.urls(granule; scheme=:https, type="GET DATA VIA DIRECT ACCESS") == []
+    @test EarthData.urls(granule; type="NOT A TYPE") == []
+    @test EarthData.download_url(granule; type="GET DATA") == "https://example.test/G1.h5"
+    @test EarthData.data_urls([granule, granule]) ==
+          ["https://example.test/G1.h5", "https://example.test/G1.h5"]
+end
+
+@testset "Granule sizes" begin
+    requests = []
+    responses = [HTTP.Response(200, [], cmr_response(["G1"], "granule"))]
+    granule = only(
+        EarthData.request(
+            "https://example.test/granules",
+            Dict("short_name" => "TEST"),
+            EarthData.Granules.UMM_G;
+            requester=recording_requester(responses, requests),
+        ),
+    )
+
+    # `Size` is 1.5 with `SizeUnit` "MB", so the unit has to be read: taking the number
+    # alone would report 1 byte where the file is 1.5 MiB.
+    @test EarthData.granule_size(granule) == round(Int, 1.5 * 1024^2)
+
+    @test EarthData.size_unit_factor("Bytes") == 1
+    @test EarthData.size_unit_factor("b") == 1
+    @test EarthData.size_unit_factor("KB") == 1024
+    @test EarthData.size_unit_factor(" mb ") == 1024^2
+    @test EarthData.size_unit_factor("GB") == 1024^3
+    @test EarthData.size_unit_factor("TB") == 1024^4
+    @test_throws ArgumentError EarthData.size_unit_factor("furlongs")
+
+    # A record with no size information reports nothing rather than zero, so a caller can
+    # tell "not stated" from "empty".
+    @test EarthData.granule_size(SizelessItem(nothing)) === nothing
 end
 
 @testset "Batch downloads" begin
@@ -201,10 +265,20 @@ end
 
     commands = Cmd[]
     folder = mktempdir()
-    paths = EarthData.download(granules, folder; runner=cmd -> push!(commands, cmd))
+    paths = EarthData.download(
+        granules,
+        folder;
+        type="GET DATA",
+        runner=cmd -> push!(commands, cmd),
+    )
 
     @test paths == [joinpath(folder, "G1.h5"), joinpath(folder, "G2.h5")]
     @test length(commands) == 1
+
+    # Without the type filter every HTTPS related URL is fetched, including the cloud
+    # credentials endpoint — which is why `type` exists.
+    unfiltered = EarthData.download(granules, folder; runner=Returns(nothing))
+    @test joinpath(folder, "s3credentials") in unfiltered
     command_string = string(only(commands))
     @test occursin("-i", command_string)
     @test occursin("-c", command_string)


### PR DESCRIPTION
**Stacked on #25 and #26 — review those first; the diff here is `src/retry.jl` + `test/retry.jl`.**

Two gaps, both found pulling ~200 GB of MCD43A3 granules through this package.

**1. Every HTTP failure is treated alike.** `parse_cmr_error` collapses any error status into one `ErrorException`, and `download` has no error handling. Both directions cost real work:

- Failing fast on a hiccup discards whatever a run had done. One 502 from a cheap unqueued pre-check ended an 11-hour job of ours in an unrelated client.
- Retrying a permanent error loops forever. A 403 from a DAAC almost always means an unaccepted end-user licence — waiting cannot fix it.

So: `TransientError` for 5xx/408/429 and connection faults, `ArgumentError` with actionable advice for 400/401/403/404, `with_retries` for backoff, and `classifying_requester` applying the same split to a CMR search through the existing `requester=` hook.

**2. `download` cannot tell a complete file from a truncated one** — it is `isfile(path) || download(url, path)`, so a cut-off transfer leaves a plausible-looking file that is never retried and only surfaces when something opens it. For HDF4 that is a GDAL error naming neither the download nor the size.

`download_verified` writes `path.part`, checks the size against `granule_size` (1 % tolerance — a UMM `Size` is often a rounded MB figure), treats a short body as transient, and only then `mv`s. Complementary to `aria2c -c`, which resumes but does not verify.

Notes:
- `Retry-After` overrides the backoff curve, clamped to 300 s.
- The attempt cap (60 × 60 s) is deliberately not the binding limit; a caller's `deadline` is. A test asserts the cap outlasts an hour.
- LP DAAC answers a bearer-authenticated GET with a 303 to CloudFront and `Downloads.download` follows it returning the full body — measured, so no redirect handling was added on speculation.

Tests offline via injected `downloader`/`requester`, including a truncated body retried to success.