### PR TITLE
Verify a download's size before accepting it

### DIFF
--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -132,6 +132,23 @@ To write a URL list for another tool:
 write_urls("urls.txt", gg)
 ```
 
+### Verified downloads
+
+`download_verified` downloads a granule's `"GET DATA"` file with a bearer token, retrying
+temporary failures and checking the size it got against `granule_size`:
+
+```julia
+download_verified(first(gg), "data")
+```
+
+It writes `path.part` and moves the file into place only once the size checks out, so an
+interrupted transfer leaves nothing behind that looks finished. That matters because a
+truncated HDF or NetCDF granule is only discovered when something opens it, and the reader's
+error for that names neither the download nor the size.
+
+This complements `aria2c`, which resumes an interrupted file but does not check whether the
+result is complete.
+
 ## Errors and retries
 
 Not every failure means the same thing, so EarthData.jl sorts them into two groups:

--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -531,6 +531,8 @@ function download(
     download(urls(items; scheme, type), folder; kwargs...)
 end
 
+include("verified_download.jl")
+
 export granules,
     collections,
     urls,
@@ -540,5 +542,6 @@ export granules,
     download_url,
     granule_size,
     write_urls,
-    download
+    download,
+    download_verified
 end

--- a/src/verified_download.jl
+++ b/src/verified_download.jl
@@ -1,0 +1,83 @@
+# Tolerance on a CMR-reported size, as a fraction. `granule_size` can be a rounded megabyte
+# figure, so it cannot be compared exactly; wide enough to absorb that rounding, narrow
+# enough to catch a cut-off transfer.
+const size_tolerance = 0.01
+
+"""
+    download_verified(url, path; bearer=token(), expected_bytes=0, verbose=true,
+                      deadline=Inf) -> path
+
+Download `url` to `path` with an Earthdata Login bearer token, retrying temporary failures.
+
+Complements the `aria2c` batch path, which resumes an interrupted file but does not check
+whether the result is complete. Two things this adds over a plain `download`:
+
+- It writes `path * ".part"` and moves it into place only on success, so an interrupted
+  transfer never leaves behind a file that looks finished.
+- When `expected_bytes > 0` (pass [`granule_size`](@ref)) the final size is checked against
+  it within `size_tolerance`. A short file is treated as a temporary failure and downloaded
+  again, because a truncated HDF or NetCDF granule surfaces much later, as a reader error
+  naming neither the download nor the size.
+
+An existing `path` is returned untouched.
+
+!!! note "The bearer header survives the redirect"
+    LP DAAC answers a bearer-authenticated GET with a 303 to CloudFront, and
+    `Downloads.download` follows it and returns the full body — measured, with and without
+    the header forwarded. The presigned-URL/`Authorization` conflict that affects some S3
+    endpoints does not arise here.
+"""
+function download_verified(
+    url::AbstractString,
+    path::AbstractString;
+    bearer=token(),
+    expected_bytes::Integer=0,
+    verbose::Bool=true,
+    deadline::Float64=Inf,
+    downloader=Downloads.download,
+)
+    isfile(path) && return path
+    mkpath(dirname(abspath(path)))
+    tmp = path * ".part"
+    headers = auth_headers(; bearer)
+    context = "download $(basename(path))"
+
+    try
+        with_retries(; context, verbose, deadline) do
+            isfile(tmp) && rm(tmp; force=true)
+            downloader(url, tmp; headers)
+            n = filesize(tmp)
+            if expected_bytes > 0 && n < expected_bytes * (1 - size_tolerance)
+                # Retryable: a short body is a cut-off transfer, not a bad request.
+                throw(
+                    TransientError(
+                        context,
+                        0,
+                        "Got $(n) bytes, expected ≈$(expected_bytes) — transfer was truncated.",
+                    ),
+                )
+            end
+            return nothing
+        end
+        mv(tmp, path; force=true)
+    catch
+        isfile(tmp) && rm(tmp; force=true)
+        rethrow()
+    end
+    return path
+end
+
+"""
+    download_verified(granule, folder="."; kwargs...) -> path
+
+Download a granule's `"GET DATA"` file into `folder`, checking its size against
+[`granule_size`](@ref).
+"""
+function download_verified(granule::AbstractJSON, folder::AbstractString="."; kwargs...)
+    url = download_url(granule; type="GET DATA")
+    isnothing(url) &&
+        error("Granule has no \"GET DATA\" URL to download: $(urls(granule))")
+    path = joinpath(folder, url_filename(url))
+    expected = something(granule_size(granule), 0)
+    return download_verified(url, path; expected_bytes=expected, kwargs...)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ include("schema_modules.jl")
 include("show.jl")
 include("search.jl")
 include("retry.jl")
+include("verified_download.jl")  # uses search.jl's fake requester
 include("spatial.jl")  # uses search.jl's fake requester
 include("auth.jl")
 

--- a/test/verified_download.jl
+++ b/test/verified_download.jl
@@ -1,0 +1,121 @@
+using HTTP
+using Test
+
+@testset "Verified download" begin
+    folder = mktempdir()
+
+    # The happy path: a full-size body lands at `path` and no `.part` survives.
+    path = joinpath(folder, "full.h5")
+    n = 4096
+    EarthData.download_verified(
+        "https://example.test/full.h5",
+        path;
+        bearer="fake-token",
+        expected_bytes=n,
+        verbose=false,
+        downloader=(url, dest; headers) -> write(dest, zeros(UInt8, n)),
+    )
+    @test filesize(path) == n
+    @test !isfile(path * ".part")
+
+    # The bearer header has to reach the downloader, since that is the point of this method
+    # existing alongside the netrc path.
+    seen = Ref{Any}(nothing)
+    EarthData.download_verified(
+        "https://example.test/hdr.h5",
+        joinpath(folder, "hdr.h5");
+        bearer="fake-token",
+        verbose=false,
+        downloader=(url, dest; headers) -> (seen[] = headers; write(dest, "x")),
+    )
+    @test ("Authorization" => "Bearer fake-token") in seen[]
+
+    # A truncated 200 is temporary, not permanent: retrying is what recovers it. Left
+    # unchecked, the short file would be opened later, and a reader's error for a corrupt
+    # HDF4 file names neither the download nor the size.
+    attempts = Ref(0)
+    short_path = joinpath(folder, "short.h5")
+    EarthData.download_verified(
+        "https://example.test/short.h5",
+        short_path;
+        bearer="fake-token",
+        expected_bytes=n,
+        verbose=false,
+        downloader=(url, dest; headers) -> begin
+            attempts[] += 1
+            write(dest, zeros(UInt8, attempts[] == 1 ? 10 : n))
+        end,
+    )
+    @test attempts[] == 2
+    @test filesize(short_path) == n
+
+    # A size within tolerance passes: `granule_size` can be a rounded megabyte figure, so an
+    # exact comparison would reject good files.
+    tol_path = joinpath(folder, "tol.h5")
+    EarthData.download_verified(
+        "https://example.test/tol.h5",
+        tol_path;
+        bearer="fake-token",
+        expected_bytes=1000,
+        verbose=false,
+        downloader=(url, dest; headers) -> write(dest, zeros(UInt8, 995)),
+    )
+    @test filesize(tol_path) == 995
+
+    # A failure leaves no partial file behind to be mistaken for a complete one.
+    fail_path = joinpath(folder, "fail.h5")
+    @test_throws ArgumentError EarthData.download_verified(
+        "https://example.test/fail.h5",
+        fail_path;
+        bearer="fake-token",
+        verbose=false,
+        downloader=(url, dest; headers) -> begin
+            write(dest, "partial")
+            throw(ArgumentError("permanent"))
+        end,
+    )
+    @test !isfile(fail_path)
+    @test !isfile(fail_path * ".part")
+
+    # An existing file is not downloaded again.
+    calls = Ref(0)
+    EarthData.download_verified(
+        "https://example.test/full.h5",
+        path;
+        bearer="fake-token",
+        verbose=false,
+        downloader=(url, dest; headers) -> (calls[] += 1),
+    )
+    @test calls[] == 0
+end
+
+@testset "Verified download of a granule" begin
+    requests = []
+    responses = [HTTP.Response(200, [], cmr_response(["G1"], "granule"))]
+    granule = only(
+        EarthData.request(
+            "https://example.test/granules",
+            Dict("short_name" => "TEST"),
+            EarthData.Granules.UMM_G;
+            requester=recording_requester(responses, requests),
+        ),
+    )
+
+    folder = mktempdir()
+    expected = EarthData.granule_size(granule)
+    seen_url = Ref("")
+    path = EarthData.download_verified(
+        granule,
+        folder;
+        bearer="fake-token",
+        verbose=false,
+        downloader=(url, dest; headers) ->
+            (seen_url[] = url; write(dest, zeros(UInt8, expected))),
+    )
+
+    # The `GET DATA` URL is the one fetched — not the S3 copy, and not the credentials
+    # endpoint an unfiltered HTTPS pick would return.
+    @test seen_url[] == "https://example.test/G1.h5"
+    @test path == joinpath(folder, "G1.h5")
+    @test filesize(path) == expected
+end


### PR DESCRIPTION
Split out of #27. **Stacked on #26 and #29** — the diff of interest here is `src/verified_download.jl` + `test/verified_download.jl`.

`download` is `isfile(path) || download(url, path)`, so a cut-off transfer leaves a file that looks complete, is never retried, and is only found when something opens it. For HDF4 that surfaces as a GDAL error naming neither the download nor the size.

`download_verified` writes `path.part`, checks the size against `granule_size` (1 % tolerance, since a UMM `Size` is often a rounded megabyte figure), treats a short body as temporary, and only then moves the file into place.

On your point about not going into full downloader mode: this is not meant to replace `aria2c`. `aria2c -c` resumes an interrupted file but does not check whether the result is complete, so the two are complementary. This is a separate function and the batch path is untouched. If you would rather document `aria2c` than add this, that is a reasonable call — the size check is the part I would keep, and it could equally be a standalone `verify_size(granule, path)`.

Tests are offline, via an injected `downloader`.