### PR TITLE
Document https_urls and s3_urls

### DIFF
--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -388,7 +388,26 @@ function urls(items::AbstractVector{<:AbstractJSON}; scheme=nothing, type=nothin
     return result
 end
 
+"""
+    https_urls(item) -> Vector{String}
+
+The item's related URLs that use the `https` scheme.
+
+Every related URL is returned, not just the data: a DOI landing page, a metadata sidecar
+and browse imagery all use `https` too. See [`data_urls`](@ref) when what you want is
+something to download.
+"""
 https_urls(item) = urls(item; scheme=:https)
+
+"""
+    s3_urls(item) -> Vector{String}
+
+The item's related URLs that use the `s3` scheme, for direct in-region S3 access.
+
+Reading these requires DAAC-issued temporary credentials and an `AWSS3` session; see
+`create_aws_config`. As with [`https_urls`](@ref), the filter is on the scheme alone, so
+the result is not necessarily just the data file.
+"""
 s3_urls(item) = urls(item; scheme=:s3)
 
 """


### PR DESCRIPTION
## Problem

The `Documentation` job is failing on `main` and therefore on every open PR:

```
Cannot resolve @ref for md"[`https_urls`](@ref)" in docs/src/reference.md.
- No docstring found in doc for binding `EarthData.https_urls`.
```

`data_urls` (added in #25) links to `https_urls` with `@ref`, but `https_urls` had no
docstring, so there was no target to resolve against. Documenter treats an unresolved
cross-reference as fatal, so `makedocs` aborts at the `cross_references` stage before
rendering.

This is not specific to any one PR — I reproduced it on a clean checkout of `f743335`.

## Fix

Docstrings for both scheme filters. `s3_urls` gets one too: it is exported and
undocumented, and `checkdocs = :all` reports that class of binding, so it is the same
failure waiting to happen.

No signatures or behaviour change; this is docstrings only.

## Verification

- `julia --project=docs -e 'include("docs/make.jl")'` now reaches `RenderDocument`, with no
  `Cannot resolve @ref` and no `No docstring found`. Fails as above without the change.
- `Pkg.test()` passes locally, 7/7 including doctests and the AWS testset.

Note: `format(".")` wants to rewrite `f(x=1)` to `f(x = 1)` across many pre-existing lines,
including untouched ones. That mismatch predates this change, so I left it alone rather than
mix a repo-wide reformat into a docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)