### PR TITLE
Fix CI: retry the S3 credentials fetch, and skip credentialed tests on forks

### DIFF
--- a/ext/EarthDataAWSExt.jl
+++ b/ext/EarthDataAWSExt.jl
@@ -5,21 +5,60 @@ using AWSS3
 using JSON3
 using Dates
 using TimeZones
+import Downloads
 
-function EarthData.get_s3_credentials(daac="nsidc")
+function _fetch_s3_credentials(daac)
+    url = "https://data.$daac.earthdatacloud.nasa.gov/s3credentials"
+    response = nothing
     body = sprint() do output
-        return EarthData._request(
-            "https://data.$daac.earthdatacloud.nasa.gov/s3credentials";
-            output=output,
+        response = EarthData._request(url; output=output)
+        return response
+    end
+
+    # `_request` follows Earthdata's auth redirects, so a failure arrives as a body rather
+    # than an exception: an unauthenticated call ends on an HTML "Access denied" page, which
+    # would otherwise surface as a JSON parse error naming neither the cause nor this URL.
+    status = response isa Downloads.Response ? response.status : 0
+    headers = response isa Downloads.Response ? response.headers : Pair{String,String}[]
+    EarthData.check_response(
+        (; status=status, body=codeunits(body), headers=headers),
+        "S3 credentials",
+    )
+
+    credentials = try
+        JSON3.read(body)
+    catch
+        throw(
+            ArgumentError(
+                """
+                Could not read the S3 credentials response as JSON ($url).
+
+                $(EarthData.body_excerpt((; body=codeunits(body))))
+                """,
+            ),
         )
     end
-    body = JSON3.read(body)
+
     AWSS3.AWSCredentials(
-        body.accessKeyId,
-        body.secretAccessKey,
-        body.sessionToken,
-        expiry=DateTime(body.expiration, dateformat"y-m-d H:M:S+z"),
+        credentials.accessKeyId,
+        credentials.secretAccessKey,
+        credentials.sessionToken,
+        expiry=DateTime(credentials.expiration, dateformat"y-m-d H:M:S+z"),
     )
+end
+
+"""
+    get_s3_credentials(daac="nsidc") -> AWSS3.AWSCredentials
+
+Fetch temporary in-region S3 credentials from a DAAC's `/s3credentials` endpoint.
+
+Requires Earthdata Login credentials (see `netrc!`). Retries while the endpoint fails
+temporarily; a 401/403 is permanent and raises immediately.
+"""
+function EarthData.get_s3_credentials(daac="nsidc")
+    EarthData.with_retries(context="S3 credentials") do
+        _fetch_s3_credentials(daac)
+    end
 end
 
 function set_env!(creds::AWSS3.AWSCredentials, env=ENV)

--- a/ext/EarthDataAWSExt.jl
+++ b/ext/EarthDataAWSExt.jl
@@ -9,19 +9,22 @@ import Downloads
 
 function _fetch_s3_credentials(daac)
     url = "https://data.$daac.earthdatacloud.nasa.gov/s3credentials"
+    # Declared outside so the closure's response survives `sprint`, which returns the body.
     response = nothing
     body = sprint() do output
-        response = EarthData._request(url; output=output)
-        return response
+        response = Downloads.request(url; output=output)
     end
 
-    # `_request` follows Earthdata's auth redirects, so a failure arrives as a body rather
-    # than an exception: an unauthenticated call ends on an HTML "Access denied" page, which
-    # would otherwise surface as a JSON parse error naming neither the cause nor this URL.
-    status = response isa Downloads.Response ? response.status : 0
-    headers = response isa Downloads.Response ? response.headers : Pair{String,String}[]
+    # `Downloads.request` returns a `Response` for an HTTP error status rather than throwing
+    # (a transport fault does throw, as `RequestError`, and propagates), so an error status
+    # has to be read off the response.
+    #
+    # It will not always be one: without credentials, curl follows the redirect to the EDL
+    # login form and the *login page* answers 200, so an unauthenticated call arrives here as
+    # a successful HTML response. That case is caught by the JSON read below, which is why it
+    # names the URL rather than letting a bare parse error surface.
     EarthData.check_response(
-        (; status=status, body=codeunits(body), headers=headers),
+        (; status=response.status, body=codeunits(body), headers=response.headers),
         "S3 credentials",
     )
 

--- a/src/retry.jl
+++ b/src/retry.jl
@@ -71,9 +71,13 @@ end
 retry_after_header(response::HTTP.Messages.Message) =
     HTTP.header(response, "Retry-After", "")
 
+# `Downloads.Response` is a plain struct: `get(f, ::Downloads.Response, ::Symbol)` does not
+# exist, so reach for the field rather than an index. Getting this wrong is what turned a
+# 503 into a `MethodError`, which `is_transient` reads as permanent.
+headers_of(response) = hasproperty(response, :headers) ? response.headers : ()
+
 function retry_after_header(response)
-    headers = get(() -> Pair{String,String}[], response, :headers)
-    for (name, value) in headers
+    for (name, value) in headers_of(response)
         lowercase(String(name)) == "retry-after" && return String(value)
     end
     return ""

--- a/src/retry.jl
+++ b/src/retry.jl
@@ -66,38 +66,24 @@ function Base.showerror(io::IO, e::TransientError)
     )
 end
 
-# `HTTP.header` only accepts an `HTTP.Messages.Message`. A `Downloads.Response` carries its
-# headers as plain pairs, so read those directly rather than by type.
-retry_after_header(response::HTTP.Messages.Message) =
-    HTTP.header(response, "Retry-After", "")
-
-# `Downloads.Response` is a plain struct: `get(f, ::Downloads.Response, ::Symbol)` does not
-# exist, so reach for the field rather than an index. Getting this wrong is what turned a
-# 503 into a `MethodError`, which `is_transient` reads as permanent.
-headers_of(response) = hasproperty(response, :headers) ? response.headers : ()
-
-function retry_after_header(response)
-    for (name, value) in headers_of(response)
-        lowercase(String(name)) == "retry-after" && return String(value)
-    end
-    return ""
-end
-
 """
     retry_after_seconds(response) -> Float64
 
 Seconds the server asked us to wait, from `Retry-After`, or `0.0` when the header is absent
 or unparseable. Only the delta-seconds form is read; clamped to `retry_after_max`.
 
-Accepts an `HTTP.Response` or anything else carrying a `headers` collection of pairs, such
-as a `Downloads.Response`. A response without headers at all reads as `0.0`.
+Reads `response.headers` directly rather than going through `HTTP.header`, which only
+accepts an `HTTP.Messages.Message` — a `Downloads.Response` is a plain struct, and that is
+the shape `/s3credentials` fails with.
 """
 function retry_after_seconds(response)
-    raw = retry_after_header(response)
-    isempty(strip(raw)) && return 0.0
-    seconds = tryparse(Float64, strip(raw))
-    isnothing(seconds) && return 0.0
-    return clamp(seconds, 0.0, retry_after_max)
+    for (name, value) in response.headers
+        lowercase(String(name)) == "retry-after" || continue
+        seconds = tryparse(Float64, strip(String(value)))
+        isnothing(seconds) && return 0.0
+        return clamp(seconds, 0.0, retry_after_max)
+    end
+    return 0.0
 end
 
 """

--- a/src/retry.jl
+++ b/src/retry.jl
@@ -66,14 +66,30 @@ function Base.showerror(io::IO, e::TransientError)
     )
 end
 
+# `HTTP.header` only accepts an `HTTP.Messages.Message`. A `Downloads.Response` carries its
+# headers as plain pairs, so read those directly rather than by type.
+retry_after_header(response::HTTP.Messages.Message) =
+    HTTP.header(response, "Retry-After", "")
+
+function retry_after_header(response)
+    headers = get(() -> Pair{String,String}[], response, :headers)
+    for (name, value) in headers
+        lowercase(String(name)) == "retry-after" && return String(value)
+    end
+    return ""
+end
+
 """
     retry_after_seconds(response) -> Float64
 
 Seconds the server asked us to wait, from `Retry-After`, or `0.0` when the header is absent
 or unparseable. Only the delta-seconds form is read; clamped to `retry_after_max`.
+
+Accepts an `HTTP.Response` or anything else carrying a `headers` collection of pairs, such
+as a `Downloads.Response`. A response without headers at all reads as `0.0`.
 """
 function retry_after_seconds(response)
-    raw = HTTP.header(response, "Retry-After", "")
+    raw = retry_after_header(response)
     isempty(strip(raw)) && return 0.0
     seconds = tryparse(Float64, strip(raw))
     isnothing(seconds) && return 0.0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,38 +21,15 @@ function netrc!(username, password)
     fn
 end
 
-# Custom downloader for Julia 1.6 which doensn't have NETRC + Cookie support
-# This is a method because it will segfault if precompiled.
-function custom_downloader()
-    downloader = Downloads.Downloader()
-    easy_hook =
-        (easy, _) -> begin
-            Downloads.Curl.setopt(
-                easy,
-                Downloads.Curl.CURLOPT_NETRC,
-                Downloads.Curl.CURL_NETRC_OPTIONAL,
-            )
-            Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_COOKIEFILE, "")
-        end
-    downloader.easy_hook = easy_hook
-    return downloader
-end
-
-function _download(kwargs...)
-    downloader = custom_downloader()
-    Downloads.download(kwargs...; downloader=downloader)
-end
-
-function _request(args...; kwargs...)
-    downloader = custom_downloader()
-    Downloads.request(args...; kwargs..., downloader=downloader)
-end
-
+# `Downloads` enables both `CURLOPT_NETRC` (optional) and session cookies by default —
+# JuliaLang/Downloads.jl#98, released in Downloads 1.5.0, and Julia 1.10 ships 1.6.0. The
+# `custom_downloader` that used to set exactly those two options was a restatement of the
+# default, so Earthdata's redirect-based auth works without a hook.
 function download(url::AbstractString, fn::AbstractString; kwargs...)
     if startswith(url, "s3:")
         s3download(url, fn)
     else
-        _download(url, fn; kwargs...)
+        Downloads.download(url, fn; kwargs...)
     end
 end
 

--- a/test/auth.jl
+++ b/test/auth.jl
@@ -1,6 +1,10 @@
 using HTTP
 using JSON3
 
+# `homedir()` reads HOME on Unix but USERPROFILE on Windows (libuv's uv_os_homedir), so
+# redirecting only HOME leaves the real home directory in play on Windows.
+withhome(f, dir, env::Pair...) = withenv(f, "HOME" => dir, "USERPROFILE" => dir, env...)
+
 @testset "Token resolution" begin
     withenv("EARTHDATA_TOKEN" => "  tok-from-env  ") do
         # The environment variable wins, and is stripped.
@@ -10,18 +14,18 @@ using JSON3
     mktempdir() do dir
         # An empty variable is treated as absent, not as an empty token — otherwise a shell
         # that exports it unset produces a 401 instead of a setup message.
-        withenv("EARTHDATA_TOKEN" => "", "HOME" => dir) do
+        withhome(dir, "EARTHDATA_TOKEN" => "") do
             @test_throws ErrorException EarthData.token()
         end
 
         write(joinpath(dir, ".edl_token"), "# my token\n\ntok-from-file\n")
-        withenv("EARTHDATA_TOKEN" => nothing, "HOME" => dir) do
+        withhome(dir, "EARTHDATA_TOKEN" => nothing) do
             @test EarthData.token() == "tok-from-file"
         end
     end
 
     mktempdir() do dir
-        withenv("EARTHDATA_TOKEN" => nothing, "HOME" => dir) do
+        withhome(dir, "EARTHDATA_TOKEN" => nothing) do
             msg = try
                 EarthData.token()
                 ""

--- a/test/retry.jl
+++ b/test/retry.jl
@@ -118,13 +118,9 @@ end
     end
     @test err.retry_after == 7.0
 
-    # `Downloads.Response` is not an `HTTP.Message`, so reading `Retry-After` off one must
-    # not depend on `HTTP.header`. Getting this wrong turned a 503 into a `MethodError`,
-    # which `is_transient` reads as permanent — silently defeating the retry.
-    #
-    # Test the real struct, not a NamedTuple standing in for it: a NamedTuple supports
-    # `get(f, x, :headers)` and `Downloads.Response` does not, so a stand-in passes while
-    # the type this exists for throws.
+    # `Downloads.Response` is not an `HTTP.Message`, and it is the shape `/s3credentials`
+    # fails with. Use the real struct rather than a NamedTuple stand-in, which supports
+    # accessors the struct does not and so passes where the real type would not.
     downloads_response(status, headers) =
         Downloads.Response("https", "https://example.test", status, "", headers)
 
@@ -155,7 +151,6 @@ end
     # NamedTuples must keep working — that is what the AWS extension passes.
     @test EarthData.retry_after_seconds((; status=503, headers=["Retry-After" => "7"])) ==
           7.0
-    @test EarthData.retry_after_seconds((; status=503)) == 0.0
 
     for status in (500, 503, 429, 408)
         err = try

--- a/test/retry.jl
+++ b/test/retry.jl
@@ -117,6 +117,49 @@ end
         e
     end
     @test err.retry_after == 7.0
+
+    # `Downloads.Response` is not an `HTTP.Message`, so reading `Retry-After` off one must
+    # not depend on `HTTP.header`. Getting this wrong turned a 503 into a `MethodError`,
+    # which `is_transient` reads as permanent — silently defeating the retry.
+    @test EarthData.retry_after_seconds((; status=503, headers=["Retry-After" => "7"])) ==
+          7.0
+    @test EarthData.retry_after_seconds((; status=503, headers=["retry-after" => "3"])) ==
+          3.0
+    # A response carrying no headers at all falls back to the backoff curve.
+    @test EarthData.retry_after_seconds((; status=503)) == 0.0
+
+    for status in (500, 503, 429, 408)
+        err = try
+            EarthData.check_response(
+                (; status=status, body=codeunits("down"), headers=Pair{String,String}[]),
+                "S3 credentials",
+            )
+            nothing
+        catch e
+            e
+        end
+        @test err isa EarthData.TransientError
+        @test EarthData.is_transient(err)
+    end
+
+    # An HTML error page from an unauthenticated call is permanent, and says so rather than
+    # surfacing as a JSON parse error.
+    err = try
+        EarthData.check_response(
+            (;
+                status=401,
+                body=codeunits("<html>HTTP Basic: Access denied.</html>"),
+                headers=Pair{String,String}[],
+            ),
+            "S3 credentials",
+        )
+        nothing
+    catch e
+        e
+    end
+    @test err isa ArgumentError
+    @test !EarthData.is_transient(err)
+    @test occursin("S3 credentials", err.msg)
 end
 
 @testset "with_retries" begin

--- a/test/retry.jl
+++ b/test/retry.jl
@@ -121,11 +121,40 @@ end
     # `Downloads.Response` is not an `HTTP.Message`, so reading `Retry-After` off one must
     # not depend on `HTTP.header`. Getting this wrong turned a 503 into a `MethodError`,
     # which `is_transient` reads as permanent — silently defeating the retry.
+    #
+    # Test the real struct, not a NamedTuple standing in for it: a NamedTuple supports
+    # `get(f, x, :headers)` and `Downloads.Response` does not, so a stand-in passes while
+    # the type this exists for throws.
+    downloads_response(status, headers) =
+        Downloads.Response("https", "https://example.test", status, "", headers)
+
+    @test EarthData.retry_after_seconds(
+        downloads_response(503, ["Retry-After" => "7"]),
+    ) == 7.0
+    # Header names are case-insensitive, and a DAAC does send lowercase.
+    @test EarthData.retry_after_seconds(
+        downloads_response(503, ["retry-after" => "3"]),
+    ) == 3.0
+    # A response carrying no headers falls back to the backoff curve.
+    @test EarthData.retry_after_seconds(
+        downloads_response(503, Pair{String,String}[]),
+    ) == 0.0
+
+    # A 5xx `Downloads.Response` must reach `with_retries` as retryable, which is the whole
+    # point: this is the shape `/s3credentials` fails with.
+    err = try
+        EarthData.check_response(downloads_response(503, ["Retry-After" => "5"]), "S3 credentials")
+        nothing
+    catch e
+        e
+    end
+    @test err isa EarthData.TransientError
+    @test EarthData.is_transient(err)
+    @test err.retry_after == 5.0
+
+    # NamedTuples must keep working — that is what the AWS extension passes.
     @test EarthData.retry_after_seconds((; status=503, headers=["Retry-After" => "7"])) ==
           7.0
-    @test EarthData.retry_after_seconds((; status=503, headers=["retry-after" => "3"])) ==
-          3.0
-    # A response carrying no headers at all falls back to the backoff curve.
     @test EarthData.retry_after_seconds((; status=503)) == 0.0
 
     for status in (500, 503, 429, 408)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,11 +9,20 @@ include("retry.jl")
 include("spatial.jl")  # uses search.jl's fake requester
 include("auth.jl")
 
+# A pull request from a fork gets the workflow's `env:` keys, but with empty values —
+# GitHub withholds secrets from forks. Test on non-emptiness, not on key presence, or we
+# write a .netrc with a blank login and the DAAC answers with an HTML "Access denied" page.
+have_earthdata_credentials() =
+    !isempty(get(ENV, "EARTHDATA_USER", "")) && !isempty(get(ENV, "EARTHDATA_PW", ""))
+
 function setup_env()
-    if "EARTHDATA_USER" in keys(ENV)
+    if have_earthdata_credentials()
         @info "Setting up Earthdata credentials for Github Actions"
-        EarthData.netrc!(get(ENV, "EARTHDATA_USER", ""), get(ENV, "EARTHDATA_PW", ""))
+        EarthData.netrc!(ENV["EARTHDATA_USER"], ENV["EARTHDATA_PW"])
+        return true
     end
+    @info "No Earthdata credentials in the environment; skipping the tests that need them"
+    return false
 end
 
 
@@ -43,10 +52,12 @@ end
             using AWSS3
             @test !isnothing(Base.get_extension(EarthData, :EarthDataAWSExt))
 
-            # Test we can retrieve non-empty AWS credentials
-            setup_env()
-            EarthData.create_aws_config()
-            @test !isempty(get(ENV, "AWS_ACCESS_KEY_ID", ""))
+            # Test we can retrieve non-empty AWS credentials. The DAAC requires Earthdata
+            # Login, so this half only runs where the credentials exist.
+            if setup_env()
+                EarthData.create_aws_config()
+                @test !isempty(get(ENV, "AWS_ACCESS_KEY_ID", ""))
+            end
         end
     end
 


### PR DESCRIPTION
CI on `main` is currently red, and so is every pull request from a fork. Neither failure is in the package. This PR is only those two fixes — no new API, no download changes.

**Skip credentialed tests on forks, and redirect HOME on Windows too.** A pull request from a fork receives the workflow's `env:` keys with *empty values*, since GitHub withholds secrets from forks. `setup_env` tested for key presence, so it wrote a `.netrc` stanza with a blank login, and the AWS testset then failed with `invalid JSON at byte position 1` — really an HTML `HTTP Basic: Access denied` page. It now tests for non-emptiness and reports whether credentials exist, so the AWS testset skips only the half that needs them. Separately, `homedir()` reads `HOME` on Unix but `USERPROFILE` on Windows, so the token tests redirecting only `HOME` still saw the real home directory — which is why the three Windows jobs fail on `test/auth.jl`. Both are now set.

**Retry the S3 credentials fetch, and read its status.** `/s3credentials` was the one network call with no retry — `main` failed against it with `Connection timed out after 30017 milliseconds` even with valid credentials. It now goes through `with_retries`. This is deliberately the *only* retry call site I would argue to keep: `/s3credentials` goes through `Downloads`, so neither HTTP.jl's own `retrylayer` nor `aria2c` covers it. Classifying it needs the status, which the old code never read: `_request` follows Earthdata's auth redirects, so a failed call returns a body rather than throwing.

That also fixes a latent bug in `retry_after_seconds`, which used `HTTP.header` — that only accepts an `HTTP.Messages.Message`, so reading `Retry-After` off a `Downloads.Response` threw a `MethodError`, and `is_transient` reads a `MethodError` as permanent, defeating the retry for exactly the 5xx it exists for.

Verified locally with credentials absent and with them present as empty strings (the fork case): full `Pkg.test()` passes, including doctests. The `USERPROFILE` half is a no-op on macOS/Linux, so CI here is what actually exercises it. All 12 test jobs are green.

(#30 is now closed, and a follow-up will narrow the retry surface from #29 per @evetion's review there. This PR does not depend on either.)