### PR TITLE
Let HTTP.jl and aria2c do the retrying

### DIFF
--- a/docs/src/downloads.md
+++ b/docs/src/downloads.md
@@ -134,40 +134,44 @@ write_urls("urls.txt", gg)
 
 ## Errors and retries
 
-Not every failure means the same thing, so EarthData.jl sorts them into two groups:
+**Retrying is not this package's job.** HTTP.jl's `retrylayer` is on by default (4 attempts,
+exponential backoff), and `aria2c` — which `download` uses for batches — has `--max-tries`,
+`--retry-wait` and `--continue`. Reach for those.
 
-- **Temporary** — 5xx, 408, 429, and connection faults. The service said nothing about the
-  request, so waiting and trying again can work. These throw `TransientError`.
-- **Permanent** — 400, 401, 403, 404. These throw an `ArgumentError` saying what to fix. A
-  403 from a DAAC nearly always means the account has not accepted the collection's licence,
-  and retrying cannot help.
+What a general-purpose client cannot know is what a DAAC *means* by a status, and in one case
+its default is wrong for Earthdata: HTTP.jl's retryable set includes **403**, but a 403 from
+a DAAC nearly always means the account has not accepted the collection's licence, so retrying
+spends the attempt budget on a request that can never succeed.
 
-Getting this wrong is costly either way: one brief 502 should not end an hours-long run, and
-a 403 should not be retried until the deadline.
+So EarthData.jl contributes the classification, not the loop:
+
+- **Temporary** — 5xx, 408, 429. The service said nothing about the request.
+- **Permanent** — 400, 401, 403, 404, each with an `ArgumentError` naming the fix. A 401
+  means the token is missing or expired (they last 60 days); a 403 means the licence.
 
 The split is by status, not by exception type. `Downloads.download` raises
 `Downloads.RequestError` both for a transport fault and for any HTTP error status, so a 403
 and a 503 arrive as the same type and only the status tells them apart.
 
-`with_retries` applies the split, backing off exponentially up to a minute. A `Retry-After`
-from the server takes priority, capped at five minutes. Pass `deadline` (an absolute
-`time()`) to bound the whole thing — the attempt cap is set high enough to wait out a
-maintenance window, so `deadline` is what should normally stop a run.
+For searches, `earthdata_requester` plugs into the existing `requester` hook:
 
 ```julia
-EarthData.with_retries(context="my download") do
-    download(url, path)
-end
+granules(short_name="MCD43A3", version="061", requester=earthdata_requester())
 ```
 
-Searches are classified through the existing `requester` hook:
+This is needed because the search path passes `status_exception=false`, which switches off
+HTTP.jl's *status-based* retrying: with no exception thrown, `retryable(::StatusError)` is
+never consulted, so a CMR 503 comes back as a plain 503 response after one attempt.
+(Connection faults still retry, since those throw either way.) Pair it with `retry_check` to
+stop 403s being retried:
 
 ```julia
-granules(short_name="MCD43A3", version="061", requester=classifying_requester())
+HTTP.request(...; retry_check=EarthData.retry_check)
 ```
 
-Without it a CMR 503 arrives as a generic `ErrorException` from `parse_cmr_error`, which
-looks the same as a rejected query.
+One exception keeps its own retry: `get_s3_credentials`. A DAAC's `/s3credentials` goes over
+`Downloads`, so neither `retrylayer` nor `aria2c` covers it, and it was the one call with no
+retry at all.
 
 ## S3 downloads
 

--- a/src/retry.jl
+++ b/src/retry.jl
@@ -1,34 +1,21 @@
 """
-Telling a temporary failure apart from a permanent one.
+Saying what an Earthdata failure means, in the cases where the status alone misleads.
 
-Both directions cost real work if you get them wrong. Giving up on a brief server hiccup
-throws away everything a long run had done. Retrying an error that can never succeed loops
-until the deadline.
+Retrying is not this package's job: HTTP.jl has `retrylayer` (on by default, 4 attempts) and
+`aria2c` has `--max-tries`/`--retry-wait`/`--continue`. What neither can know is what a DAAC
+means by a given status, and for one status HTTP.jl's default is wrong here:
 
-Temporary — the service said nothing about the request:
+- HTTP.jl's retryable set is `(403, 408, 409, 429, 500, 502, 503, 504, 599)`. A 403 from a
+  DAAC nearly always means the account has not accepted the collection's licence, so retrying
+  it spends the attempt budget on a request that can never succeed. See [`retry_check`](@ref).
+- **401** means the token is missing, malformed or expired (they last 60 days), not that the
+  request was wrong.
 
-- **5xx**, plus **408** and **429** (the request was fine; come back later).
-- Connection faults: DNS, connect, timeout, reset, truncated body.
-
-Permanent — retrying cannot help:
-
-- **400** — the query is wrong.
-- **401** — the token is missing, malformed or expired (they last 60 days).
-- **403** — the token works, but the account has not accepted the collection's licence or
-  approved the DAAC application.
-- **404** — it is not there.
-
-The status decides, not the exception type: `Downloads.RequestError` is thrown both for a
-transport fault and for any HTTP error status, so a 403 and a 503 reach us as the same type.
-See [`error_status`](@ref).
+Permanent here is 400, 401, 403 and 404; temporary is 5xx, 408 and 429. The status decides,
+not the exception type: `Downloads.RequestError` is thrown both for a transport fault and for
+any HTTP error status, so a 403 and a 503 reach us as the same type. See
+[`error_status`](@ref).
 """
-
-const retry_base = 2.0
-const retry_max_backoff = 60.0
-
-# The attempt cap should not be what stops a run; a caller's `deadline` should. A download is
-# minutes of work, so a maintenance window is worth waiting out rather than discarding.
-const retry_attempts = 60
 
 const transient_statuses = (408, 429, 500, 502, 503, 504)
 
@@ -196,19 +183,24 @@ function check_response(r, context::AbstractString)
 end
 
 """
-    with_retries(f; context, attempts=retry_attempts, verbose=true, deadline=Inf) -> f()
+    with_retries(f; context, attempts=4, verbose=true, deadline=Inf) -> f()
 
-Call `f`, retrying while it fails temporarily (see [`is_transient`](@ref)) with exponential
-backoff from `retry_base` up to `retry_max_backoff`. Other errors propagate on the first
-attempt, and the last failure is rethrown as-is so the user sees the service's own message.
+Retry `f` while it fails temporarily (see [`is_transient`](@ref)), backing off exponentially.
 
-`deadline` is an absolute `time()` bounding the retrying, and it — not `attempts` — is what
-should normally stop a run. A `Retry-After` from the server overrides the backoff upward.
+Deliberately kept for one caller: `get_s3_credentials`. A DAAC's `/s3credentials` goes over
+`Downloads` rather than HTTP.jl, so neither `retrylayer` nor `aria2c` covers it, and it was
+the one call with no retry of its own — `main` failed against it with
+`Connection timed out after 30017 milliseconds` on valid credentials.
+
+Anything going over HTTP.jl should use its own `retries`/`retry_check` instead of this, and
+anything downloading should use `aria2c`. `attempts` matches HTTP.jl's default of 4 rather
+than trying to outlast a maintenance window; pass `deadline` (an absolute `time()`) to bound
+the whole thing.
 """
 function with_retries(
     f;
     context::AbstractString,
-    attempts::Integer=retry_attempts,
+    attempts::Integer=4,
     verbose::Bool=true,
     deadline::Float64=Inf,
 )
@@ -219,7 +211,7 @@ function with_retries(
             return f()
         catch err
             (is_transient(err) && attempt < attempts) || rethrow()
-            backoff = min(retry_base * 2.0^(attempt - 1), retry_max_backoff)
+            backoff = min(2.0^attempt, 60.0)
             requested = err isa TransientError ? err.retry_after : 0.0
             requested > 0 && (backoff = max(backoff, requested))
             time() + backoff >= deadline && rethrow()
@@ -231,20 +223,41 @@ function with_retries(
 end
 
 """
-    classifying_requester(inner=HTTP.request, context="CMR search")
+    retry_check(s, ex, req, resp, resp_body) -> Bool
 
-Wrap a `requester` (as accepted by `request`, [`granules`](@ref) and [`collections`](@ref))
-so a temporary status throws [`TransientError`](@ref) instead of being turned into a plain
-`ErrorException` by `parse_cmr_error`.
+A `retry_check` for HTTP.jl's `retrylayer`, so a DAAC 403 is not retried.
 
-Only temporary statuses are intercepted. The rest are passed through untouched, so
-`parse_cmr_error`'s reading of CMR's `errors` array is still what the caller sees.
+HTTP.jl retries `(403, 408, 409, 429, 500, 502, 503, 504, 599)`. The 403 is defensible for a
+generic client — some CDNs do return a transient one — but for Earthdata it means an
+unaccepted end-user licence, and retrying it can never succeed.
 
 ```julia
-granules(short_name="MCD43A3", version="061", requester=classifying_requester())
+HTTP.request(method, url, headers; retry_check=EarthData.retry_check)
 ```
 """
-function classifying_requester(inner=HTTP.request, context::AbstractString="CMR search")
+retry_check(s, ex, req, resp, resp_body) =
+    !isnothing(resp) && is_transient_status(resp.status)
+
+"""
+    earthdata_requester(inner=HTTP.request, context="CMR search")
+
+A `requester` (as accepted by `request`, [`granules`](@ref) and [`collections`](@ref)) that
+re-throws a temporary CMR status as [`TransientError`](@ref), handing it back to HTTP.jl's
+own retry layer instead of letting `parse_cmr_error` flatten it into an `ErrorException`.
+
+Needed because the search path passes `status_exception=false`, which switches off HTTP.jl's
+*status-based* retrying: with no exception thrown, `retryable(::StatusError)` is never
+consulted, so a CMR 503 comes back as a plain 503 response after a single attempt. Connection
+faults are unaffected — those throw either way, and HTTP.jl already retries them.
+
+A permanent status is passed through untouched, so `parse_cmr_error`'s reading of CMR's
+`errors` array is still what the caller sees.
+
+```julia
+granules(short_name="MCD43A3", version="061", requester=earthdata_requester())
+```
+"""
+function earthdata_requester(inner=HTTP.request, context::AbstractString="CMR search")
     return function (args...; kwargs...)
         r = inner(args...; kwargs...)
         if is_transient_status(r.status)

--- a/test/retry.jl
+++ b/test/retry.jl
@@ -186,6 +186,36 @@ end
     @test occursin("S3 credentials", err.msg)
 end
 
+@testset "retry_check" begin
+    # HTTP.jl retries 403 by default. For a DAAC that is an unaccepted licence, so it must not
+    # be retried — the one place the generic client's default is wrong for Earthdata.
+    req = HTTP.Request("GET", "/")
+    @test !EarthData.retry_check(nothing, nothing, req, HTTP.Response(403, [], ""), nothing)
+
+    for status in (408, 429, 500, 502, 503, 504)
+        @test EarthData.retry_check(
+            nothing,
+            nothing,
+            req,
+            HTTP.Response(status, [], ""),
+            nothing,
+        )
+    end
+
+    for status in (400, 401, 404)
+        @test !EarthData.retry_check(
+            nothing,
+            nothing,
+            req,
+            HTTP.Response(status, [], ""),
+            nothing,
+        )
+    end
+
+    # No response at all (a connection fault) is HTTP.jl's own business, not ours.
+    @test !EarthData.retry_check(nothing, nothing, req, nothing, nothing)
+end
+
 @testset "with_retries" begin
     # A temporary failure is retried; `attempts` bounds it.
     calls = Ref(0)
@@ -217,19 +247,15 @@ end
     end
     @test calls[] == 1
 
-    # The attempt cap should not be what normally stops a run: at the maximum backoff it has
-    # to outlast a maintenance window, leaving `deadline` in charge.
-    @test EarthData.retry_attempts * EarthData.retry_max_backoff >= 3600
-
     @test sprint(showerror, EarthData.TransientError("ctx", 502, "gateway")) |>
           s -> occursin("502", s) && occursin("ctx", s)
 end
 
-@testset "classifying_requester" begin
+@testset "earthdata_requester" begin
     # A CMR 503 should be retryable rather than collapsed into parse_cmr_error's generic
     # ErrorException.
     inner = (args...; kwargs...) -> HTTP.Response(503, [], "CMR is down")
-    @test_throws EarthData.TransientError EarthData.classifying_requester(inner)(
+    @test_throws EarthData.TransientError EarthData.earthdata_requester(inner)(
         "POST",
         "https://example.test",
         [],
@@ -239,7 +265,7 @@ end
     # own `errors` array.
     body = JSON3.write(Dict("errors" => ["Parameter [nope] was not recognized."]))
     permanent = (args...; kwargs...) -> HTTP.Response(400, [], body)
-    r = EarthData.classifying_requester(permanent)("POST", "https://example.test", [])
+    r = EarthData.earthdata_requester(permanent)("POST", "https://example.test", [])
     @test r.status == 400
 
     requests = []
@@ -248,7 +274,7 @@ end
         "https://example.test/granules",
         Dict("short_name" => "TEST"),
         EarthData.Granules.UMM_G;
-        requester=EarthData.classifying_requester(
+        requester=EarthData.earthdata_requester(
             recording_requester(responses, requests),
         ),
     )


### PR DESCRIPTION
Acting on @evetion's review of #29: this package should not carry a retry manager. He was right, and this reverts that part.

`retrylayer` in HTTP.jl is on by default (4 attempts, exponential backoff), and `aria2c` — which `download` already uses for batches — has `--max-tries`, `--retry-wait` and `--continue`. #29 rebuilt both.

## What is kept, and why

What a general-purpose client cannot know is what a DAAC *means* by a status — and for one status HTTP.jl's default is actively wrong here. Its retryable set is `(403, 408, 409, 429, 500, 502, 503, 504, 599)`, but a 403 from a DAAC nearly always means the account has not accepted the collection's licence, so retrying spends the attempt budget on a request that can never succeed.

So: keep the classification, drop the loop.

- **`retry_check`** plugs into `retrylayer` and stops a 403 being retried.
- **`classifying_requester` → `earthdata_requester`**, and its docstring now explains why it needs to exist at all. The search path passes `status_exception=false`, which switches off HTTP.jl's *status-based* retrying entirely: with no exception thrown, `retryable(::StatusError)` is never consulted. Measured against a local 503 server:

  | | server hits |
  |---|---|
  | `status_exception=false` (what `cmr_http_request` uses) | 1 |
  | default | 5 |

  Connection faults are unaffected — those throw either way, and HTTP.jl retries them.
- **`with_retries` survives for one caller**, `get_s3_credentials`. `/s3credentials` goes over `Downloads`, so neither `retrylayer` nor `aria2c` covers it, and it was the one call with no retry at all. `attempts` drops 60 → 4 to match HTTP.jl rather than trying to outlast a maintenance window. `retry_base`, `retry_max_backoff` and `retry_attempts` are gone.

## A bug this also fixes

`retry_after_seconds` went through `HTTP.header`, which only accepts an `HTTP.Messages.Message`. On a `Downloads.Response` — the shape `/s3credentials` fails with — a 503 raised a `MethodError`, and `is_transient` reads a `MethodError` as permanent. The retry was defeated for exactly the 5xx it exists for.

Now reads the field via `hasproperty`. The test uses a real `Downloads.Response` rather than a NamedTuple stand-in, because a NamedTuple supports `get(f, x, :headers)` and hides the bug.

## Notes

- Branched off `main`, so it does not overlap #33 (CI fix, still open).
- #30 is closed — its size check compared one file against `granule_size`, which sums *all* files in a granule.
- Full `Pkg.test()` green including doctests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)