### PR TITLE
Dispatch on element and tuple types in cmr_spatial

### DIFF
--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -46,33 +46,43 @@ cmr_spatial(param::Symbol, value) = cmr_spatial(param, GeoInterface.trait(value)
 cmr_spatial(::Symbol, value::AbstractString) = value
 cmr_spatial(::Symbol, ::Nothing) = nothing
 
-function cmr_spatial(param::Symbol, value::AbstractVector)
-    # A vector of numbers is the coordinate list itself; a vector of anything else is a
-    # repeated parameter.
-    all(v -> v isa Real, value) && return join_coords(value)
-    return [cmr_spatial(param, v) for v in value]
-end
+# A vector of numbers is the coordinate list itself; a vector of anything else is a repeated
+# parameter, which CMR reads as the union.
+cmr_spatial(::Symbol, value::AbstractVector{<:Real}) = join_coords(value)
 
-function cmr_spatial(param::Symbol, value::Tuple)
-    # `circle` is the one parameter with no matching geometry, because a radius is not part of
-    # any GeoInterface trait, so it takes a centre plus a radius in metres.
+cmr_spatial(param::Symbol, value::AbstractVector) =
+    [cmr_spatial(param, v) for v in value]
+
+# Tuples are resolved before the trait, because GeoInterface reads *any* numeric tuple as a
+# `PointTrait` — including `circle`'s `(lon, lat, radius_m)`, which is not a 3D point.
+
+# `circle` is the one parameter with no matching geometry, since a radius is not part of any
+# GeoInterface trait: it takes a centre plus a radius in metres. Arity is per-parameter — a
+# 3-tuple is a circle but not a point — so it stays part of the check rather than being
+# absorbed into `NTuple{N,Real}` for every parameter.
+function cmr_spatial(param::Symbol, value::NTuple{N,Real}) where {N}
     if param === :circle
-        length(value) == 2 && !(value[1] isa Real) && return circle_string(value...)
-        length(value) == 3 || throw(
+        N == 3 || throw(
             ArgumentError(
-                "`circle` takes (lon, lat, radius_m) or (point, radius_m); got " *
-                "$(length(value)) values.",
+                "`circle` takes (lon, lat, radius_m) or (point, radius_m); got $(N) values.",
             ),
         )
     elseif param === :point
-        length(value) == 2 ||
-            throw(ArgumentError("`point` takes (lon, lat); got $(length(value)) values."))
+        N == 2 || throw(ArgumentError("`point` takes (lon, lat); got $(N) values."))
     end
-    all(v -> v isa Real, value) || throw(
-        ArgumentError("`$(param)` takes a tuple of numbers; got $(typeof(value))."),
-    )
     return join_coords(value)
 end
+
+cmr_spatial(param::Symbol, value::Tuple{Any,Real}) =
+    param === :circle ? circle_string(value...) :
+    throw(ArgumentError("`$(param)` does not take (point, radius_m); use `circle`."))
+
+cmr_spatial(param::Symbol, value::Tuple) = throw(
+    ArgumentError(
+        "`$(param)` takes a tuple of numbers, or (point, radius_m) for `circle`; got " *
+        "$(typeof(value)).",
+    ),
+)
 
 function circle_string(centre, radius::Real)
     GeoInterface.trait(centre) isa GeoInterface.PointTrait ||
@@ -81,9 +91,10 @@ function circle_string(centre, radius::Real)
 end
 
 # An `Extent` is a `RectangleTrait`, but only carries X and Y if it was built with them.
+# `GeoInterface.extent` is the identity on an `Extent`, so it covers both cases.
 function cmr_spatial(param::Symbol, ::GeoInterface.RectangleTrait, value)
     wrong_param(param, :bounding_box, "a bounding box")
-    ext = value isa Extents.Extent ? value : GeoInterface.extent(value)
+    ext = GeoInterface.extent(value)
     isnothing(ext) &&
         throw(ArgumentError("Cannot get an extent from $(typeof(value)) for `bounding_box`."))
     (haskey(ext, :X) && haskey(ext, :Y)) || throw(

--- a/test/spatial.jl
+++ b/test/spatial.jl
@@ -93,6 +93,18 @@ const ccw_ring = "-49,66,-49,68,-51,68,-51,66,-49,66"
         @test_throws ArgumentError EarthData.cmr_spatial(:point, Dict("x" => 1))
         # Small coordinates must not come out in exponent notation, which CMR rejects.
         @test EarthData.cmr_spatial(:point, (1.0e-5, 0.0)) == "0.00001,0"
+
+        # A coordinate list is matched on the element type now, so an eltype that only
+        # happens to hold numbers is not one. Literals infer a concrete eltype
+        # (`[-51, 66]` is `Vector{Int64}`), so this needs an explicit `Any[...]` to hit —
+        # and reaching it means the caller built the vector by hand.
+        @test EarthData.cmr_spatial(:bounding_box, [-51, 66, -49, 68]) == "-51,66,-49,68"
+        @test EarthData.cmr_spatial(:bounding_box, Real[-51, 66, -49, 68]) ==
+              "-51,66,-49,68"
+        @test_throws ArgumentError EarthData.cmr_spatial(
+            :bounding_box,
+            Any[-51, 66, -49, 68],
+        )
     end
 
     @testset "vector of geometries" begin


### PR DESCRIPTION
All three inline points from @evetion's review on #24:

- `AbstractVector{<:Real}` replaces the `all(v -> v isa Real, value)` scan.
- `NTuple{N,Real}` replaces the same scan on tuples, with `N` carrying the arity so `(point, radius_m)` becomes its own `Tuple{Any,Real}` method instead of a length-and-`isa` branch.
- `GeoInterface.extent` is the identity on an `Extent` (`extent(e) === e`), so the `value isa Extents.Extent ? value : ...` special-case was dead weight.

Two things that did not simplify as far as they look like they should, both now commented in the source:

**Tuples must be resolved before the trait.** GeoInterface reads *any* numeric tuple as a `PointTrait`:

```julia
GeoInterface.trait((1.0, 2.0))        # PointTrait()
GeoInterface.trait((1.0, 2.0, 500.0)) # PointTrait()  <- circle's (lon, lat, radius_m)
```

So trait-first dispatch silently takes `circle`'s 3-tuple as a 3D point.

**Arity stays per-parameter.** A 3-tuple is a valid `circle` and an invalid `point`, so the length check cannot move into the signature for all parameters at once.

## One behaviour change

Matching on the element type drops `Vector{Any}`, which the old runtime scan accepted:

| | old | new |
|---|---|---|
| `[-51, 66, -49, 68]` (`Vector{Int64}`) | ok | ok |
| `Real[-51, 66, -49, 68]` | ok | ok |
| `Any[-51, 66, -49, 68]` | ok | `ArgumentError` |

Literals infer a concrete eltype, so reaching it takes an explicit `Any[...]`. I took the narrowing — the error names what the parameter accepts — but it is a behaviour change rather than a pure refactor, so it is tested in both directions rather than left implicit. Say if you would rather keep it working.

On the `Any`-fields/dispatch point in your review body: making the parameter a type (`P{:point}`) rather than a runtime `Symbol` does let the valid (param, geometry) pairs become methods and removes `wrong_param` entirely. I prototyped it and it works, but it rewrites every method in the file, so it seems better judged on its own than smuggled in here.

Branched off `main`; independent of #33 and #34. Full `Pkg.test()` green including doctests; conversion testset 30 → 33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)