### PR TITLE
Treat a SizeUnit of "NA" as no unit, not as bytes

### DIFF
--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -452,14 +452,18 @@ const size_unit_factors = Dict(
 )
 
 """
-    size_unit_factor(unit) -> Int
+    size_unit_factor(unit) -> Union{Int,Nothing}
 
 Bytes per `unit`, for the `SizeUnit` values UMM allows (`"Bytes"`, `"KB"`, `"MB"`, `"GB"`,
 `"TB"`; binary multiples). Throws for an unrecognised unit rather than guessing, since a
 wrong factor silently misreports a size by three orders of magnitude.
+
+`"NA"` returns `nothing`: providers use it to say they recorded no unit, so the accompanying
+`Size` cannot be converted at all.
 """
 function size_unit_factor(unit::AbstractString)
     key = uppercase(strip(unit))
+    key == "NA" && return nothing
     haskey(size_unit_factors, key) ||
         throw(ArgumentError("Unrecognised UMM SizeUnit: $(repr(unit))"))
     return size_unit_factors[key]
@@ -475,7 +479,8 @@ Size of a granule in bytes, from `DataGranule.ArchiveAndDistributionInformation`
 `Size` is unit-less on its own, and providers do report units other than bytes, so reading
 the number without the unit is how a megabyte figure gets mistaken for a byte count. A
 record that gives `Size` with no `SizeUnit` is read as `default_unit`, which is what the
-DAACs mean in practice; pass `default_unit` explicitly if a provider differs.
+DAACs mean in practice; pass `default_unit` explicitly if a provider differs. A `SizeUnit`
+of `"NA"` is not a unit, so such an entry is skipped rather than guessed at.
 
 Sizes of multiple files are summed, since together they are the granule.
 """
@@ -490,8 +495,9 @@ function granule_size(granule::AbstractJSON; default_unit::AbstractString="MB")
         bytes = entry.SizeInBytes
         if isnothing(bytes)
             isnothing(entry.Size) && continue
-            unit = something(entry.SizeUnit, default_unit)
-            bytes = round(Int, entry.Size * size_unit_factor(unit))
+            factor = size_unit_factor(something(entry.SizeUnit, default_unit))
+            isnothing(factor) && continue
+            bytes = round(Int, entry.Size * factor)
         end
         total += bytes
         found = true

--- a/test/search.jl
+++ b/test/search.jl
@@ -67,6 +67,21 @@ struct SizelessItem <: EarthData.AbstractJSON
     DataGranule::Nothing
 end
 
+# Enough of a granule to exercise `granule_size`'s unit handling directly.
+struct SizeEntry
+    Name::String
+    Size::Union{Nothing,Float64}
+    SizeUnit::Union{Nothing,String}
+    SizeInBytes::Union{Nothing,Int}
+end
+struct SizedDataGranule
+    ArchiveAndDistributionInformation::Vector{SizeEntry}
+end
+struct SizedItem <: EarthData.AbstractJSON
+    DataGranule::SizedDataGranule
+end
+sized_item(entries...) = SizedItem(SizedDataGranule(collect(entries)))
+
 function cmr_response(ids, concept_type; hits=length(ids))
     umm = concept_type == "granule" ? granule_umm : collection_umm
     JSON3.write(
@@ -293,6 +308,20 @@ end
     @test EarthData.size_unit_factor("GB") == 1024^3
     @test EarthData.size_unit_factor("TB") == 1024^4
     @test_throws ArgumentError EarthData.size_unit_factor("furlongs")
+
+    # ATL06 reports `Size` with `SizeUnit` "NA", which means the provider recorded no unit
+    # rather than that the number is bytes. It has no factor, so the entry is skipped.
+    @test EarthData.size_unit_factor("NA") === nothing
+    @test EarthData.granule_size(sized_item(SizeEntry("f.h5", 16.0, "NA", nothing))) ===
+          nothing
+
+    # A sibling entry that does carry a usable size still counts.
+    @test EarthData.granule_size(
+        sized_item(
+            SizeEntry("f.h5", 16.0, "NA", nothing),
+            SizeEntry("f.png", nothing, nothing, 2048),
+        ),
+    ) == 2048
 
     # A record with no size information reports nothing rather than zero, so a caller can
     # tell "not stated" from "empty".


### PR DESCRIPTION
`granule_size(first(granules(short_name="ATL06")))` throws `ArgumentError: Unrecognised UMM SizeUnit: "NA"`. ATL06 reports `Size: 16.0, SizeUnit: "NA"` — `NA` means the provider recorded no unit, not that the number is bytes, so converting it with a guessed factor would overstate the size a millionfold.

`size_unit_factor` now returns `nothing` for it and `granule_size` skips the entry, matching what it already does when a record reports no size at all. Verified live: ATL06 returns `nothing`, GEDI02_A and NSIDC-0051 are unchanged.

Co-authored-by: Claude <noreply@anthropic.com>
