### PR TITLE
Make create_aws_config's warm-cache branch runnable

### DIFF
--- a/ext/EarthDataAWSExt.jl
+++ b/ext/EarthDataAWSExt.jl
@@ -68,7 +68,8 @@ function set_env!(creds::AWSS3.AWSCredentials, env=ENV)
     env["AWS_ACCESS_KEY_ID"] = creds.access_key_id
     env["AWS_SECRET_ACCESS_KEY"] = creds.secret_key
     env["AWS_SESSION_TOKEN"] = creds.token
-    env["AWS_SESSION_EXPIRES"] = creds.expiry
+    # `ENV` holds strings; assigning the `DateTime` itself raises a `MethodError`.
+    env["AWS_SESSION_EXPIRES"] = string(creds.expiry)
 end
 
 function EarthData.create_aws_config(daac="nsidc", region="us-west-2")
@@ -83,7 +84,7 @@ function EarthData.create_aws_config(daac="nsidc", region="us-west-2")
             get(ENV, "AWS_ACCESS_KEY_ID", ""),
             get(ENV, "AWS_SECRET_ACCESS_KEY", ""),
             get(ENV, "AWS_SESSION_TOKEN", ""),
-            expiration=DateTime(get(ENV, "AWS_SESSION_EXPIRES", typemin(DateTime))),
+            expiry=expiration,
         )
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using EarthData
 using Test
 using Documenter
+using Dates
 
 include("schema_modules.jl")
 include("show.jl")
@@ -51,6 +52,27 @@ end
             @test isnothing(Base.get_extension(EarthData, :EarthDataAWSExt))
             using AWSS3
             @test !isnothing(Base.get_extension(EarthData, :EarthDataAWSExt))
+
+            # The warm-cache branch reuses unexpired credentials from the environment.
+            # `ENV` only takes strings, and the expiry keyword is `expiry`, not
+            # `expiration` — either mistake made this branch raise instead of run.
+            ext = Base.get_extension(EarthData, :EarthDataAWSExt)
+            env = Dict{String,String}()
+            creds = AWSS3.AWSCredentials("id", "secret", "token"; expiry=DateTime(2030))
+            ext.set_env!(creds, env)
+            @test env["AWS_SESSION_EXPIRES"] == "2030-01-01T00:00:00"
+            @test DateTime(env["AWS_SESSION_EXPIRES"]) == DateTime(2030)
+
+            withenv(
+                "AWS_ACCESS_KEY_ID" => "cached-id",
+                "AWS_SECRET_ACCESS_KEY" => "cached-secret",
+                "AWS_SESSION_TOKEN" => "cached-token",
+                "AWS_SESSION_EXPIRES" => string(DateTime(2030)),
+            ) do
+                config = EarthData.create_aws_config()
+                @test config.credentials.access_key_id == "cached-id"
+                @test config.credentials.expiry == DateTime(2030)
+            end
 
             # Test we can retrieve non-empty AWS credentials. The DAAC requires Earthdata
             # Login, so this half only runs where the credentials exist.


### PR DESCRIPTION
The branch that reuses cached credentials could never run. `AWSCredentials` takes `expiry`, not `expiration`, and its signature has no `kwargs...` to absorb the wrong name; separately, `set_env!` assigned a `DateTime` to `ENV`, which only accepts `String`. Either mistake alone raised, so a second `create_aws_config()` call with unexpired credentials errored instead of reusing them.

Both fixed, and the branch now has offline test coverage — it had none, which is why this went unnoticed.

Co-authored-by: Claude <noreply@anthropic.com>
