### PR TITLE
Accept Date and DateTime for the temporal parameters

### DIFF
--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -21,6 +21,7 @@ include("show.jl")
 include("stub.jl")  # empty methods that are actually defined in extensions
 include("retry.jl")
 include("spatial.jl")
+include("temporal.jl")
 
 const world = Extent(X=(-180.0, 180.0), Y=(-90.0, 90.0))
 
@@ -298,8 +299,16 @@ function cmr_query(query::Dict; page_num, page_size)
     for (k, v) in query
         isnothing(v) && continue
         key = string(k)
-        # Spatial parameters also accept geometries; everything else is passed on as given.
-        q[key] = Symbol(key) in spatial_params ? cmr_spatial(Symbol(key), v) : v
+        # Spatial parameters also accept geometries and temporal ones dates; everything
+        # else is passed on as given.
+        sym = Symbol(key)
+        q[key] = if sym in spatial_params
+            cmr_spatial(sym, v)
+        elseif sym in temporal_params
+            cmr_temporal(sym, v)
+        else
+            v
+        end
     end
     return q
 end

--- a/src/temporal.jl
+++ b/src/temporal.jl
@@ -1,0 +1,95 @@
+"""
+Date support for CMR's temporal search parameters.
+
+CMR takes a temporal constraint as ISO 8601 in UTC, either a single instant or a
+comma-separated `start,end` range with either side optionally empty for an open bound.
+Writing those by hand is easy to get subtly wrong, so the temporal keywords also accept
+dates, in any of the forms below.
+
+| value                                | sent to CMR as                              |
+|:-------------------------------------|:--------------------------------------------|
+| `Date(2019, 4, 18)`                  | `2019-04-18T00:00:00Z`                      |
+| `DateTime(2019, 4, 18, 6)`           | `2019-04-18T06:00:00Z`                      |
+| `(Date(2019, 4, 18), Date(2019, 5))` | `2019-04-18T00:00:00Z,2019-05-01T00:00:00Z` |
+| `(Date(2019, 4, 18), nothing)`       | `2019-04-18T00:00:00Z,`                     |
+| `(nothing, Date(2019, 5))`           | `,2019-05-01T00:00:00Z`                     |
+| `Date(2019, 4, 18):Day(1):Date(2019, 5)` | its span, not one clause per day        |
+| `Extent(Ti=(start, stop))`           | the `Ti` bounds                             |
+
+Strings pass through untouched, so existing calls are unaffected. A vector becomes a
+repeated parameter, which CMR reads as the union.
+"""
+
+const temporal_params = (
+    :temporal,
+    :updated_since,
+    :created_at,
+    :revision_date,
+    :production_date,
+    :equator_crossing_date,
+    :has_granules_created_at,
+    :has_granules_revised_at,
+)
+
+# CMR wants UTC with a `Z`. A `Date` is midnight; a `DateTime` is taken as already UTC,
+# since CMR has no way to read a local offset. `Dates.ISODateTimeFormat` is not a
+# substitute: it emits fractional seconds. `Dates.format` needs the `DateTime`, since it
+# has no `hour` for a `Date`.
+cmr_datetime(d::Union{Date,DateTime}) =
+    Dates.format(DateTime(d), dateformat"yyyy-mm-dd\THH:MM:SS\Z")
+
+"""
+    cmr_temporal(param::Symbol, value)
+
+Convert `value` into the string CMR expects for the temporal parameter `param`. Strings and
+`nothing` pass through; dates are converted; anything else raises an `ArgumentError` naming
+what `param` accepts.
+"""
+cmr_temporal(::Symbol, value::AbstractString) = value
+cmr_temporal(::Symbol, ::Nothing) = nothing
+
+cmr_temporal(::Symbol, value::Union{Date,DateTime}) = cmr_datetime(value)
+
+# A range. Either side may be `nothing` for an open bound, which CMR reads as an empty field.
+const TemporalBound = Union{Date,DateTime,Nothing}
+
+cmr_temporal(param::Symbol, ::Tuple{Nothing,Nothing}) = throw(
+    ArgumentError("`$(param)` needs at least one bound; both sides of the range are nothing."),
+)
+
+function cmr_temporal(param::Symbol, (start, stop)::Tuple{TemporalBound,TemporalBound})
+    isnothing(start) ||
+        isnothing(stop) ||
+        DateTime(start) <= DateTime(stop) ||
+        throw(ArgumentError("`$(param)` range ends before it starts: $(start) to $(stop)."))
+    return string(
+        isnothing(start) ? "" : cmr_datetime(start),
+        ",",
+        isnothing(stop) ? "" : cmr_datetime(stop),
+    )
+end
+
+# A vector of dates is a repeated parameter, which CMR reads as the union.
+cmr_temporal(param::Symbol, value::AbstractVector) = [cmr_temporal(param, v) for v in value]
+
+# A date range means the span it covers, not one clause per element: `Date(2019,1,1):Day(1):
+# Date(2019,5,1)` is an `AbstractVector`, so without this it would become a 121-clause union.
+cmr_temporal(param::Symbol, value::AbstractRange{<:Union{Date,DateTime}}) =
+    cmr_temporal(param, extrema(value))
+
+# An `Extent`'s `Ti` bounds, so a search can be constrained by what `Extents.extent` returns
+# for a raster — the temporal counterpart of `bounding_box` taking `X`/`Y`.
+function cmr_temporal(param::Symbol, value::Extents.Extent)
+    haskey(value, :Ti) || throw(
+        ArgumentError("`$(param)` needs an extent with a `Ti` bound; got $(keys(value))."),
+    )
+    return cmr_temporal(param, value.Ti)
+end
+
+cmr_temporal(param::Symbol, value) = throw(
+    ArgumentError(
+        "`$(param)` takes a string, a `Date`/`DateTime`, a (start, stop) tuple of those " *
+        "(either side may be `nothing`), a date range, or an `Extent` with a `Ti`; got " *
+        "$(typeof(value)).",
+    ),
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("show.jl")
 include("search.jl")
 include("retry.jl")
 include("spatial.jl")  # uses search.jl's fake requester
+include("temporal.jl")  # likewise
 include("auth.jl")
 
 # A pull request from a fork gets the workflow's `env:` keys, but with empty values —

--- a/test/temporal.jl
+++ b/test/temporal.jl
@@ -1,0 +1,76 @@
+using Dates
+using Extents
+using HTTP
+using Test
+
+@testset "Temporal conversion" begin
+    # A `Date` is midnight UTC; a `DateTime` keeps its time. Both need the trailing Z, and
+    # neither may come out in Julia's default `2019-04-18T00:00:00` form without it.
+    @test EarthData.cmr_temporal(:temporal, Date(2019, 4, 18)) == "2019-04-18T00:00:00Z"
+    @test EarthData.cmr_temporal(:temporal, DateTime(2019, 4, 18, 6, 30)) ==
+          "2019-04-18T06:30:00Z"
+
+    # Ranges, including the open-ended forms CMR reads as an empty field.
+    @test EarthData.cmr_temporal(:temporal, (Date(2019, 4, 18), Date(2019, 4, 20))) ==
+          "2019-04-18T00:00:00Z,2019-04-20T00:00:00Z"
+    @test EarthData.cmr_temporal(:temporal, (Date(2019, 4, 18), nothing)) ==
+          "2019-04-18T00:00:00Z,"
+    @test EarthData.cmr_temporal(:temporal, (nothing, Date(2019, 4, 20))) ==
+          ",2019-04-20T00:00:00Z"
+
+    # Strings pass through, so existing calls are unaffected.
+    @test EarthData.cmr_temporal(:temporal, "2019-04-18T00:00:00Z,") ==
+          "2019-04-18T00:00:00Z,"
+    @test EarthData.cmr_temporal(:temporal, nothing) === nothing
+
+    # A vector is a repeated parameter, which CMR reads as the union.
+    @test EarthData.cmr_temporal(:temporal, [Date(2019, 1, 1), Date(2020, 1, 1)]) ==
+          ["2019-01-01T00:00:00Z", "2020-01-01T00:00:00Z"]
+
+    # A range is an `AbstractVector`, but it means the span it covers: without its own
+    # method this would become one clause per element — 121 of them here.
+    @test EarthData.cmr_temporal(:temporal, Date(2019, 1, 1):Day(1):Date(2019, 5, 1)) ==
+          "2019-01-01T00:00:00Z,2019-05-01T00:00:00Z"
+
+    # An `Extent`'s `Ti`, so `Extents.extent(raster)` can constrain a search directly, the
+    # way `bounding_box` already takes its `X`/`Y`.
+    @test EarthData.cmr_temporal(
+        :temporal,
+        Extent(Ti=(Date(2019, 4, 18), Date(2019, 4, 20))),
+    ) == "2019-04-18T00:00:00Z,2019-04-20T00:00:00Z"
+    @test_throws ArgumentError EarthData.cmr_temporal(
+        :temporal,
+        Extent(X=(-51.0, -49.0)),
+    )
+
+    # A backwards range would silently return nothing from CMR rather than erroring.
+    @test_throws ArgumentError EarthData.cmr_temporal(
+        :temporal,
+        (Date(2019, 4, 20), Date(2019, 4, 18)),
+    )
+    @test_throws ArgumentError EarthData.cmr_temporal(:temporal, (nothing, nothing))
+    @test_throws ArgumentError EarthData.cmr_temporal(:temporal, 2019)
+end
+
+@testset "Temporal parameters in a search" begin
+    # Every date-valued CMR parameter goes through the conversion, not just `temporal`.
+    for key in EarthData.temporal_params
+        # Two of the eight are collection-only (`has_granules_*_at`) and two granule-only
+        # (`production_date`, `equator_crossing_date`), so each has to go to the endpoint
+        # that accepts it — with a matching response body to parse.
+        search, id, kind =
+            key in fieldnames(EarthData.GranuleRequest) ?
+            (EarthData.granules, "G1", "granule") :
+            (EarthData.collections, "C1", "collection")
+        requests = []
+        responses = [HTTP.Response(200, [], cmr_response([id], kind))]
+        search(;
+            key => (Date(2019, 4, 18), Date(2019, 4, 20)),
+            requester=recording_requester(responses, requests),
+        )
+        @test occursin(
+            "$(key)=$(HTTP.URIs.escapeuri("2019-04-18T00:00:00Z,2019-04-20T00:00:00Z"))",
+            requests[1].body,
+        )
+    end
+end


### PR DESCRIPTION
The eight date-valued CMR parameters were raw pass-throughs, so callers hand-formatted ISO 8601 despite `Dates` already being a dependency. They now also take a `Date`, a `DateTime`, a `(start, stop)` tuple with either side `nothing` for an open bound, a date range, or an `Extent`'s `Ti` bounds — mirroring what #24 did for space: a `temporal_params` tuple and `cmr_temporal`, so `cmr_query` gains one branch. Strings pass through untouched.

A range means the span it covers: it is an `AbstractVector`, so without its own method `Date(2019,1,1):Day(1):Date(2019,5,1)` would silently become a 121-clause union query. Accepting an `Extent` lets `Extents.extent(raster)` constrain a search the way `bounding_box` already takes its `X`/`Y`.

A backwards range throws rather than returning CMR's empty result. Verified live: the `Date` and range forms return the same granule as the equivalent string.

Co-authored-by: Claude <noreply@anthropic.com>
