### PR TITLE
Add Extents.extent for granules

### DIFF
--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -21,8 +21,7 @@ include("show.jl")
 include("stub.jl")  # empty methods that are actually defined in extensions
 include("retry.jl")
 include("spatial.jl")
-
-const world = Extent(X=(-180.0, 180.0), Y=(-90.0, 90.0))
+include("extent.jl")
 
 const granule_version = "v1.6.6"
 const collection_version = "v1.17.0"

--- a/src/extent.jl
+++ b/src/extent.jl
@@ -94,10 +94,12 @@ present only if the record supports it, so test with `haskey` before reading. Co
 no time dimension ignore `Ti`; `Rasters` warns when cropping a purely spatial raster with
 one, so pass only the keys you need.
 
+`Extents` is not re-exported, so reach it either with `using Extents` or, as here, through
+`EarthData.Extents`.
+
 ```jldoctest
-using Extents
 g = first(granules(short_name="GEDI02_A"))
-ext = Extents.extent(g);
+ext = EarthData.Extents.extent(g);
 haskey(ext, :X) && haskey(ext, :Ti)
 # output
 true

--- a/src/extent.jl
+++ b/src/extent.jl
@@ -1,0 +1,114 @@
+"""
+`Extents.extent` for UMM records, so a search result can constrain the rest of the
+ecosystem: `Rasters.crop(raster; to=Extents.extent(granule))`, `GeometryOps`, or another
+search.
+
+A granule states its coverage as any of `BoundingRectangles`, `GPolygons`, `Points` or
+`Lines`, and may carry several; the result is the extent enclosing all of them. `Ti` comes
+from the `TemporalExtent`, which is either a range or a single instant.
+"""
+
+# CMR reports times as ISO 8601 with a `Z` and sometimes milliseconds, neither of which
+# `DateTime`'s parser accepts, so read only the leading `yyyy-mm-ddTHH:MM:SS`. An
+# unparseable value is skipped rather than guessed at; `tryparse` already returns `nothing`
+# for an empty or blank string. Sub-second precision is dropped, which no extent needs.
+umm_datetime(s::AbstractString) =
+    tryparse(DateTime, SubString(s, 1, min(lastindex(s), 19)))
+umm_datetime(::Nothing) = nothing
+
+point_extent(p) = Extent(X=(p.Longitude, p.Longitude), Y=(p.Latitude, p.Latitude))
+
+# Fold rather than `reduce` over a lazy generator: `reduce` without an `init` cannot infer
+# the `Extent` type parameters, so every intermediate boxes — 192 KB for a 1000-point
+# boundary. `nothing` is the empty accumulator, since `Extents.union` already absorbs it but
+# cannot start from it.
+grow_extent(acc, ::Nothing) = acc
+grow_extent(::Nothing, ext) = ext
+grow_extent(acc, ext) = Extents.union(acc, ext)
+
+function points_extent(points)
+    acc = nothing
+    for p in points
+        acc = grow_extent(acc, point_extent(p))
+    end
+    return acc
+end
+
+# The geometry helpers are deliberately untyped: `Granules` and `Collections` generate
+# field-identical `BoundingRectangleType`/`PointType`/`LineType`/`GPolygonType`, so the same
+# walk serves both and `Extents.extent(::UMM_C)` needs only its own top-level method.
+geometry_extent(r) = Extent(
+    X=(r.WestBoundingCoordinate, r.EastBoundingCoordinate),
+    Y=(r.SouthBoundingCoordinate, r.NorthBoundingCoordinate),
+)
+
+# Dispatch on the field a geometry carries rather than on its module-qualified type.
+geometry_extent(p::Union{Granules.GPolygonType,Collections.GPolygonType}) =
+    points_extent(p.Boundary.Points)  # An ExclusiveZone is a hole inside, so it cannot widen.
+geometry_extent(l::Union{Granules.LineType,Collections.LineType}) = points_extent(l.Points)
+geometry_extent(p::Union{Granules.PointType,Collections.PointType}) = point_extent(p)
+
+function geometries_extent(geometry)
+    acc = nothing
+    for collection in
+        (geometry.BoundingRectangles, geometry.GPolygons, geometry.Points, geometry.Lines)
+        isnothing(collection) && continue
+        for g in collection
+            acc = grow_extent(acc, geometry_extent(g))
+        end
+    end
+    return acc
+end
+
+function spatial_extent(record)
+    spatial = @something record.SpatialExtent return nothing
+    horizontal = @something spatial.HorizontalSpatialDomain return nothing
+    return geometries_extent(@something horizontal.Geometry return nothing)
+end
+
+function temporal_extent(granule::Granules.UMM_G)
+    temporal = @something granule.TemporalExtent return nothing
+    range = temporal.RangeDateTime
+    isnothing(range) && return instant_extent(umm_datetime(temporal.SingleDateTime))
+    # An open-ended granule is bounded by whichever end it does state.
+    bounds = filter(
+        !isnothing,
+        (umm_datetime(range.BeginningDateTime), umm_datetime(range.EndingDateTime)),
+    )
+    isempty(bounds) && return nothing
+    return (first(bounds), last(bounds))
+end
+
+instant_extent(::Nothing) = nothing
+instant_extent(instant::DateTime) = (instant, instant)
+
+"""
+    Extents.extent(granule::Granules.UMM_G) -> Union{Extent,Nothing}
+
+The granule's bounding extent, with `X`/`Y` in degrees and `Ti` from its temporal coverage,
+or `nothing` when the record states no coverage at all.
+
+`X`/`Y` enclose every geometry the record carries — CMR states coverage as bounding
+rectangles, polygons, points or lines, and a granule may hold more than one. A key is
+present only if the record supports it, so test with `haskey` before reading. Consumers with
+no time dimension ignore `Ti`; `Rasters` warns when cropping a purely spatial raster with
+one, so pass only the keys you need.
+
+```jldoctest
+using Extents
+g = first(granules(short_name="GEDI02_A"))
+ext = Extents.extent(g);
+haskey(ext, :X) && haskey(ext, :Ti)
+# output
+true
+```
+"""
+function Extents.extent(granule::Granules.UMM_G)
+    spatial = spatial_extent(granule)
+    temporal = temporal_extent(granule)
+    isnothing(temporal) && return spatial
+    # `Extent(; NamedTuple()..., Ti=t)` is `Extent(Ti=t)`, so the spatial-less case needs no
+    # branch of its own.
+    bounds = isnothing(spatial) ? NamedTuple() : Extents.bounds(spatial)
+    return Extent(; bounds..., Ti=temporal)
+end

--- a/test/extent.jl
+++ b/test/extent.jl
@@ -1,0 +1,116 @@
+using Dates
+using Extents
+using JSON3
+using Test
+
+# A minimal granule carrying `geometry` as its horizontal spatial domain and `temporal` as
+# its temporal extent, parsed the way a real response is so the structs are built by the
+# same path the package uses.
+function extent_granule(geometry; temporal=nothing)
+    umm = Dict{String,Any}(
+        "GranuleUR" => "G1",
+        "CollectionReference" => Dict("ShortName" => "TEST", "Version" => "001"),
+        "MetadataSpecification" =>
+            Dict("URL" => "https://example.test", "Version" => "1.6.6", "Name" => "UMM-G"),
+        "ProviderDates" => [Dict("Type" => "Insert", "Date" => "2020-01-01T00:00:00Z")],
+        "SpatialExtent" => Dict("HorizontalSpatialDomain" => Dict("Geometry" => geometry)),
+    )
+    isnothing(temporal) || (umm["TemporalExtent"] = temporal)
+    return JSON3.read(JSON3.write(umm), EarthData.Granules.UMM_G)
+end
+
+point(lon, lat) = Dict("Longitude" => lon, "Latitude" => lat)
+
+rectangle(west, east, south, north) = Dict(
+    "WestBoundingCoordinate" => west,
+    "EastBoundingCoordinate" => east,
+    "SouthBoundingCoordinate" => south,
+    "NorthBoundingCoordinate" => north,
+)
+
+@testset "Granule extent" begin
+    # West/east are X and south/north are Y; mixing that pairing up is the classic way to
+    # transpose an extent, and it would still parse.
+    ext = Extents.extent(
+        extent_granule(Dict("BoundingRectangles" => [rectangle(-51.0, -49.0, 40.0, 60.0)])),
+    )
+    @test ext == Extent(X=(-51.0, -49.0), Y=(40.0, 60.0))
+
+    # A polygon is bounded by its outer boundary. An `ExclusiveZone` is a hole *inside* it,
+    # so it cannot widen the extent.
+    polygon = Dict(
+        "Boundary" => Dict(
+            "Points" =>
+                [point(-10.0, 0.0), point(5.0, 0.0), point(5.0, 10.0), point(-10.0, 0.0)],
+        ),
+    )
+    @test Extents.extent(extent_granule(Dict("GPolygons" => [polygon]))) ==
+          Extent(X=(-10.0, 5.0), Y=(0.0, 10.0))
+
+    # Points and lines are the other two forms CMR uses. A point is a zero-width extent.
+    @test Extents.extent(extent_granule(Dict("Points" => [point(3.0, 4.0)]))) ==
+          Extent(X=(3.0, 3.0), Y=(4.0, 4.0))
+
+    line = Dict("Points" => [point(0.0, 0.0), point(2.0, -3.0)])
+    @test Extents.extent(extent_granule(Dict("Lines" => [line]))) ==
+          Extent(X=(0.0, 2.0), Y=(-3.0, 0.0))
+
+    # A record may carry several geometries, of more than one kind, and the result has to
+    # enclose all of them rather than the first collection found.
+    @test Extents.extent(
+        extent_granule(
+            Dict(
+                "BoundingRectangles" => [rectangle(-20.0, -15.0, -1.0, 1.0)],
+                "Points" => [point(30.0, 40.0)],
+            ),
+        ),
+    ) == Extent(X=(-20.0, 30.0), Y=(-1.0, 40.0))
+
+    # No coverage at all reports nothing rather than a zero-width extent at the origin.
+    @test Extents.extent(extent_granule(Dict{String,Any}())) === nothing
+end
+
+@testset "Granule extent time" begin
+    geometry = Dict("BoundingRectangles" => [rectangle(-51.0, -49.0, 40.0, 60.0)])
+
+    # CMR writes times with a `Z` and often milliseconds, neither of which `DateTime`'s
+    # parser accepts, so both have to be trimmed rather than passed through.
+    ext = Extents.extent(
+        extent_granule(
+            geometry;
+            temporal=Dict(
+                "RangeDateTime" => Dict(
+                    "BeginningDateTime" => "2019-04-04T18:05:55Z",
+                    "EndingDateTime" => "2019-04-04T19:38:36.000Z",
+                ),
+            ),
+        ),
+    )
+    @test ext.Ti == (DateTime(2019, 4, 4, 18, 5, 55), DateTime(2019, 4, 4, 19, 38, 36))
+    # The spatial keys survive alongside Ti.
+    @test ext.X == (-51.0, -49.0)
+
+    # A single instant is a zero-width interval, so it still composes with a range search.
+    ext = Extents.extent(
+        extent_granule(
+            geometry;
+            temporal=Dict("SingleDateTime" => "2019-04-04T18:05:55.000Z"),
+        ),
+    )
+    @test ext.Ti == (DateTime(2019, 4, 4, 18, 5, 55), DateTime(2019, 4, 4, 18, 5, 55))
+
+    # An open-ended range is bounded by whichever end it does state.
+    ext = Extents.extent(
+        extent_granule(
+            geometry;
+            temporal=Dict(
+                "RangeDateTime" =>
+                    Dict("BeginningDateTime" => "2019-04-04T18:05:55Z"),
+            ),
+        ),
+    )
+    @test ext.Ti == (DateTime(2019, 4, 4, 18, 5, 55), DateTime(2019, 4, 4, 18, 5, 55))
+
+    # Without a temporal extent there is no Ti at all, so callers must use `haskey`.
+    @test !haskey(Extents.extent(extent_granule(geometry)), :Ti)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("show.jl")
 include("search.jl")
 include("retry.jl")
 include("spatial.jl")  # uses search.jl's fake requester
+include("extent.jl")
 include("auth.jl")
 
 # A pull request from a fork gets the workflow's `env:` keys, but with empty values —


### PR DESCRIPTION
A granule states its spatial and temporal coverage, but nothing got it back out — constraining anything by a search result meant reaching into `SpatialExtent.HorizontalSpatialDomain.Geometry` by hand. `Extents.extent(::UMM_G)` returns `X`/`Y` in degrees plus `Ti` from the temporal extent, enclosing every geometry the record carries: CMR states coverage as `BoundingRectangles`, `GPolygons`, `Points` or `Lines`, and a granule may hold more than one kind — GEDI/ATL06/MODIS use polygons, GRACE rectangles. Also deletes `const world`, an unused `Extent` with no references anywhere.

The geometry helpers are untyped on purpose: `Granules` and `Collections` generate field-identical geometry structs, so `Extents.extent(::UMM_C)` later needs only its own top-level method rather than a parallel implementation.

Verified live against GEDI02_A, ATL06, GRACE and NSIDC-0051 — the extents match the raw coordinates in the records. Note `Rasters.crop(raster; to=granule)` needs the GeoInterface trait work deferred in #32; the docstring shows `to=Extents.extent(granule)`, which works today.

Co-authored-by: Claude <noreply@anthropic.com>
