### PR TITLE
Make the CMR endpoint selectable, and add UAT

### DIFF
--- a/src/EarthData.jl
+++ b/src/EarthData.jl
@@ -30,8 +30,57 @@ const version = granule_version
 
 const granule_umm_json_version = replace(granule_version, "." => "_")
 const collection_umm_json_version = replace(collection_version, "." => "_")
-const granule_url = "https://cmr.earthdata.nasa.gov/search/granules.umm_json_$granule_umm_json_version"
-const collection_url = "https://cmr.earthdata.nasa.gov/search/collections.umm_json_$collection_umm_json_version"
+
+"""
+    System(; cmr_url, edl_host)
+
+An Earthdata deployment: [`PROD`](@ref) or [`UAT`](@ref).
+
+UAT is where NASA stages a collection before it goes public, so it is what a provider tests
+against. Pass one as `system` to [`granules`](@ref) or [`collections`](@ref).
+
+`cmr_url` is a base URL rather than a host, so a proxy or a local CMR can be reached by
+constructing a `System` directly. `edl_host` is a bare hostname, since that is what `.netrc`
+and curl match on.
+
+!!! note "Search only, for now"
+    Nothing reads `edl_host` yet — [`token_from_netrc`](@ref) and [`netrc_credentials`](@ref)
+    still target production. A UAT *search* works; UAT *authentication* does not, and a
+    production token rejected by UAT reports a production token page.
+"""
+Base.@kwdef struct System
+    cmr_url::String = "https://cmr.earthdata.nasa.gov"
+    edl_host::String = "urs.earthdata.nasa.gov"
+end
+
+"""
+    PROD
+
+The operational Earthdata deployment, and the default for every search.
+"""
+const PROD = System()
+
+"""
+    UAT
+
+Earthdata's user-acceptance-testing deployment, holding staged and pre-release collections.
+
+```julia
+granules(short_name="GEDI02_A", system=EarthData.UAT)
+```
+"""
+const UAT = System(
+    cmr_url="https://cmr.uat.earthdata.nasa.gov",
+    edl_host="uat.urs.earthdata.nasa.gov",
+)
+
+search_url(system::System, concept::AbstractString, umm_version::AbstractString) =
+    "$(system.cmr_url)/search/$(concept).umm_json_$(umm_version)"
+
+granule_url(system::System=PROD) =
+    search_url(system, "granules", granule_umm_json_version)
+collection_url(system::System=PROD) =
+    search_url(system, "collections", collection_umm_json_version)
 
 abstract type AbstractRequest end
 
@@ -225,6 +274,7 @@ function granules(;
     all=false,
     method=:POST,
     requester=HTTP.request,
+    system::System=PROD,
     kwargs...,
 )
     d = Dict(kwargs)
@@ -232,7 +282,7 @@ function granules(;
     isempty(uk) ||
         throw(ArgumentError("Unknown keyword argument(s): " * join(string.(uk), ", ")))
     request(
-        granule_url,
+        granule_url(system),
         Dict(zip(string.(keys(d)), values(d))),
         Granules.UMM_G;
         page_num,
@@ -257,6 +307,7 @@ function collections(;
     all=false,
     method=:POST,
     requester=HTTP.request,
+    system::System=PROD,
     kwargs...,
 )
     d = Dict(kwargs)
@@ -264,7 +315,7 @@ function collections(;
     isempty(uk) ||
         throw(ArgumentError("Unknown keyword argument(s): " * join(string.(uk), ", ")))
     request(
-        collection_url,
+        collection_url(system),
         Dict(zip(string.(keys(d)), values(d))),
         Collections.UMM_C;
         page_num,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("show.jl")
 include("search.jl")
 include("retry.jl")
 include("spatial.jl")  # uses search.jl's fake requester
+include("system.jl")  # likewise
 include("auth.jl")
 
 # A pull request from a fork gets the workflow's `env:` keys, but with empty values —

--- a/test/schema_modules.jl
+++ b/test/schema_modules.jl
@@ -13,8 +13,8 @@ using EarthData
     @test !isdefined(EarthData, :UMM_C)
     @test EarthData.responsetype(EarthData.Collections.UMM_C) ===
           EarthData.CollectionSearchResponse
-    @test occursin("granules.umm_json_v1_6_6", EarthData.granule_url)
-    @test occursin("collections.umm_json_v1_17_0", EarthData.collection_url)
+    @test occursin("granules.umm_json_v1_6_6", EarthData.granule_url())
+    @test occursin("collections.umm_json_v1_17_0", EarthData.collection_url())
 
     spec = EarthData.Granules.MetadataSpecificationType(
         "https://example.com/schema",

--- a/test/search.jl
+++ b/test/search.jl
@@ -241,7 +241,7 @@ end
     @test result isa Vector{EarthData.Collections.UMM_C}
     @test only(result).ShortName == "C1"
     @test only(result).MetadataDates[1].Date === nothing
-    @test requests[1].url == EarthData.collection_url
+    @test requests[1].url == EarthData.collection_url()
     @test occursin("short_name=C1", requests[1].body)
     @test_throws ArgumentError EarthData.collections(not_a_cmr_keyword=1)
 end

--- a/test/system.jl
+++ b/test/system.jl
@@ -1,0 +1,50 @@
+using HTTP
+using Test
+
+@testset "System endpoints" begin
+    # PROD is the default, so an unqualified search must be unchanged by this addition.
+    @test EarthData.granule_url() == EarthData.granule_url(EarthData.PROD)
+    @test occursin("cmr.earthdata.nasa.gov", EarthData.granule_url(EarthData.PROD))
+    @test occursin("cmr.uat.earthdata.nasa.gov", EarthData.granule_url(EarthData.UAT))
+    @test occursin("cmr.uat.earthdata.nasa.gov", EarthData.collection_url(EarthData.UAT))
+
+    # The UMM version travels with the host: pointing at UAT must not silently downgrade the
+    # schema the response is parsed against.
+    for system in (EarthData.PROD, EarthData.UAT)
+        @test occursin("granules.umm_json_v1_6_6", EarthData.granule_url(system))
+        @test occursin("collections.umm_json_v1_17_0", EarthData.collection_url(system))
+    end
+
+    # `system` has to reach the request, not just the URL builder.
+    for (search, concept, id) in (
+        (EarthData.granules, "granule", "G1"),
+        (EarthData.collections, "collection", "C1"),
+    )
+        requests = []
+        responses = [HTTP.Response(200, [], cmr_response([id], concept))]
+        search(;
+            short_name="TEST",
+            system=EarthData.UAT,
+            requester=recording_requester(responses, requests),
+        )
+        @test occursin("cmr.uat.earthdata.nasa.gov", requests[1].url)
+    end
+
+    # `cmr_url` is a base URL, not a host, so a proxy or a local CMR is reachable — which a
+    # bare hostname could not express, since the scheme and port would be baked in.
+    local_cmr = EarthData.System(cmr_url="http://localhost:3003")
+    @test EarthData.granule_url(local_cmr) ==
+          "http://localhost:3003/search/granules.umm_json_v1_6_6"
+    # Omitted fields fall back to production.
+    @test local_cmr.edl_host == EarthData.PROD.edl_host
+
+    # Default stays PROD when `system` is omitted.
+    requests = []
+    responses = [HTTP.Response(200, [], cmr_response(["G1"], "granule"))]
+    EarthData.granules(;
+        short_name="TEST",
+        requester=recording_requester(responses, requests),
+    )
+    @test occursin("cmr.earthdata.nasa.gov", requests[1].url)
+    @test !occursin("uat", requests[1].url)
+end


### PR DESCRIPTION
The CMR search URLs were `const`s pointing at the operational deployment, so reaching UAT — where NASA stages a collection before it goes public — meant editing the package. `granule_url`/`collection_url` become functions of a `System`, and `granules`/`collections` take a `system` keyword defaulting to `PROD`. The UMM version travels with the host, so pointing at UAT does not silently change the schema a response is parsed against.

`System` stores `cmr_url` as a base URL rather than a bare hostname, so a proxy or a local CMR can be reached by constructing one directly; `edl_host` stays a hostname, since that is what `.netrc` and curl match on.

Nothing reads `edl_host` yet — `auth.jl`'s token endpoints are still hardcoded to production, and rerouting those changes `token_from_netrc`'s signature, so it belongs with the auth resolver work. The docstring says so, since a UAT search working while UAT auth does not is worth stating where users look.

Verified live: GEDI02_A returns 192,634 hits on PROD and 1,022 on UAT, with different granule IDs.

Co-authored-by: Claude <noreply@anthropic.com>
